### PR TITLE
Upgraded to latest image client and flattened downloads mapping

### DIFF
--- a/downloads/downloader_dataset_test.go
+++ b/downloads/downloader_dataset_test.go
@@ -61,15 +61,12 @@ func TestGetDownloadForDataset(t *testing.T) {
 		downloads, err := d.Get(nil, testDatasetVersionDownloadParams, TypeDatasetVersion)
 
 		So(downloads.Available, ShouldHaveLength, 1)
-		actual, found := downloads.Available["csv"][VariantDefault]
+		actual, found := downloads.Available["csv"]
 		So(found, ShouldBeTrue)
 
 		So(actual, ShouldResemble, Info{
-			URL:     datasetDownload.URL,
-			Size:    datasetDownload.Size,
 			Public:  datasetDownload.Public,
 			Private: datasetDownload.Private,
-			Skipped: false,
 		})
 
 		So(downloads.IsPublished, ShouldBeFalse)
@@ -114,15 +111,12 @@ func TestGetDownloadForDataset(t *testing.T) {
 
 		So(downloads.Available, ShouldHaveLength, 1)
 
-		actual, found := downloads.Available["csv"][VariantDefault]
+		actual, found := downloads.Available["csv"]
 		So(found, ShouldBeTrue)
 
 		So(actual, ShouldResemble, Info{
-			URL:     datasetDownload.URL,
-			Size:    datasetDownload.Size,
 			Public:  datasetDownload.Public,
 			Private: datasetDownload.Private,
-			Skipped: false,
 		})
 
 		So(downloads.IsPublished, ShouldBeFalse)

--- a/downloads/downloader_filter_test.go
+++ b/downloads/downloader_filter_test.go
@@ -61,15 +61,12 @@ func TestGetDownloadsForFilterOutput(t *testing.T) {
 		downloads, err := d.Get(nil, testFilterOutputDownloadParams, TypeFilterOutput)
 
 		So(downloads.Available, ShouldHaveLength, 1)
-		csv, found := downloads.Available["csv"][VariantDefault]
+		csv, found := downloads.Available["csv"]
 		So(found, ShouldBeTrue)
 
 		So(csv, ShouldResemble, Info{
-			URL:     csvDownload.URL,
-			Size:    csvDownload.Size,
 			Public:  csvDownload.Public,
 			Private: csvDownload.Private,
-			Skipped: csvDownload.Skipped,
 		})
 
 		So(downloads.IsPublished, ShouldBeFalse)
@@ -94,15 +91,12 @@ func TestGetDownloadsForFilterOutput(t *testing.T) {
 
 		So(downloads.Available, ShouldHaveLength, 1)
 
-		csv, found := downloads.Available["csv"][VariantDefault]
+		csv, found := downloads.Available["csv"]
 		So(found, ShouldBeTrue)
 
 		So(csv, ShouldResemble, Info{
-			URL:     csvDownload.URL,
-			Size:    csvDownload.Size,
 			Public:  csvDownload.Public,
 			Private: csvDownload.Private,
-			Skipped: csvDownload.Skipped,
 		})
 
 		So(downloads.IsPublished, ShouldBeTrue)

--- a/downloads/downloader_image_test.go
+++ b/downloads/downloader_image_test.go
@@ -2,7 +2,6 @@ package downloads
 
 import (
 	"errors"
-	"strconv"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/image"
@@ -55,7 +54,7 @@ func TestGetDownloadsForImage(t *testing.T) {
 	})
 
 	Convey("should return publish false if image not published", t, func() {
-		imgDownload := getTestImageDownload()
+		imgDownload := getTestImageDownload(false)
 		image := getTestImage(false, &imgDownload)
 
 		imgCli := successfulImageClient(ctrl, testImageDownloadParams, image)
@@ -71,15 +70,12 @@ func TestGetDownloadsForImage(t *testing.T) {
 		downloads, err := d.Get(nil, testImageDownloadParams, TypeImage)
 
 		So(downloads.Available, ShouldHaveLength, 1)
-		img, found := downloads.Available[testExt][testVariant]
+		img, found := downloads.Available[testVariant]
 		So(found, ShouldBeTrue)
 
 		So(img, ShouldResemble, Info{
-			URL:     imgDownload.Href,
-			Size:    strconv.Itoa(imgDownload.Size),
-			Public:  imgDownload.Public,
+			Public:  imgDownload.Href,
 			Private: imgDownload.Private,
-			Skipped: false,
 		})
 
 		So(downloads.IsPublished, ShouldBeFalse)
@@ -87,7 +83,7 @@ func TestGetDownloadsForImage(t *testing.T) {
 	})
 
 	Convey("should return expected values if downloads is not empty", t, func() {
-		imgDownload := getTestImageDownload()
+		imgDownload := getTestImageDownload(true)
 		img := getTestImage(true, &imgDownload)
 
 		imgCli := successfulImageClient(ctrl, testImageDownloadParams, img)
@@ -104,15 +100,12 @@ func TestGetDownloadsForImage(t *testing.T) {
 
 		So(downloads.Available, ShouldHaveLength, 1)
 
-		csv, found := downloads.Available[testExt][testVariant]
+		csv, found := downloads.Available[testVariant]
 		So(found, ShouldBeTrue)
 
 		So(csv, ShouldResemble, Info{
-			URL:     imgDownload.Href,
-			Size:    strconv.Itoa(imgDownload.Size),
-			Public:  imgDownload.Public,
+			Public:  imgDownload.Href,
 			Private: imgDownload.Private,
-			Skipped: false,
 		})
 
 		So(downloads.IsPublished, ShouldBeTrue)
@@ -140,11 +133,11 @@ func TestGetDownloadsForImage(t *testing.T) {
 	})
 }
 
-func getTestImageDownload() image.ImageDownload {
+func getTestImageDownload(isPublic bool) image.ImageDownload {
 	return image.ImageDownload{
 		Href:    "/downloadURL",
 		Size:    666,
-		Public:  "/public/download/url",
+		Public:  isPublic,
 		Private: "/private/download/url",
 	}
 }
@@ -156,8 +149,8 @@ func getTestImage(isPublished bool, dl *image.ImageDownload) image.Image {
 	}
 
 	if dl != nil {
-		i.Downloads = map[string]map[string]image.ImageDownload{
-			testExt: {testVariant: *dl},
+		i.Downloads = map[string]image.ImageDownload{
+			testVariant: *dl,
 		}
 	}
 	return i

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-download-service
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.14.0
+	github.com/ONSdigital/dp-api-clients-go v1.15.0
 	github.com/ONSdigital/dp-healthcheck v1.0.4
 	github.com/ONSdigital/dp-net v1.0.4
 	github.com/ONSdigital/dp-rchttp v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/ONSdigital/dp-api-clients-go v1.1.0/go.mod h1:9lqor0I7caCnRWr04gU/r7x5dqxgoODob8L48q+cE4E=
-github.com/ONSdigital/dp-api-clients-go v1.14.0 h1:QPWy2MzCdhFw4tEyrlfmQ5zgCP1+NDiyRuHLKqQXgWs=
-github.com/ONSdigital/dp-api-clients-go v1.14.0/go.mod h1:pLIrakQgoa+W23OodCaSI8RHOYaEnxd4kb1bk5LWXtw=
+github.com/ONSdigital/dp-api-clients-go v1.15.0 h1:eQZclMipvVpbT3spP8lAGo/e1dBAUk1zpR5lCA715wU=
+github.com/ONSdigital/dp-api-clients-go v1.15.0/go.mod h1:pLIrakQgoa+W23OodCaSI8RHOYaEnxd4kb1bk5LWXtw=
 github.com/ONSdigital/dp-frontend-models v1.1.0/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -47,38 +47,20 @@ var (
 // generate download Info with provided public URL
 func infoWithPublicURL(publicDownload string) downloads.Info {
 	return downloads.Info{
-		URL:     "/downloadURL",
-		Size:    "666",
-		Public:  publicDownload,
-		Skipped: false,
+		Public: publicDownload,
 	}
 }
 
 // generate download Info with provided private S3 key
 func infoWithPrivateURL(privateS3Key string) downloads.Info {
 	return downloads.Info{
-		URL:     "/downloadURL",
-		Size:    "666",
 		Private: fmt.Sprintf(testPrivateDownloadFmt, privateS3Key),
-		Skipped: false,
-	}
-}
-
-// generate download Info with no URL
-func infoWithNoURLs() downloads.Info {
-	return downloads.Info{
-		URL:     "/downloadURL",
-		Size:    "666",
-		Skipped: false,
 	}
 }
 
 // generate download Info with an invalid private URL
 func infoWithInvalidPrivateURL() downloads.Info {
 	return downloads.Info{
-		URL:     "/downloadURL",
-		Size:    "666",
-		Skipped: false,
 		Private: "@£$%^&*()_+",
 	}
 }
@@ -86,52 +68,52 @@ func infoWithInvalidPrivateURL() downloads.Info {
 var (
 	publishedDatasetDownloadPublicURL = downloads.Model{
 		IsPublished: true,
-		Available:   map[string]map[string]downloads.Info{"csv": {downloads.VariantDefault: infoWithPublicURL(testPublicDatasetDownload)}},
+		Available:   map[string]downloads.Info{"csv": infoWithPublicURL(testPublicDatasetDownload)},
 	}
 
 	publishedImageDownloadPublicURL = downloads.Model{
 		IsPublished: true,
-		Available:   map[string]map[string]downloads.Info{"png": {"1280x720": infoWithPublicURL(testPublicImageDownload)}},
+		Available:   map[string]downloads.Info{"1280x720": infoWithPublicURL(testPublicImageDownload)},
 	}
 
 	publishedDatasetDownloadPrivateURL = downloads.Model{
 		IsPublished: true,
-		Available:   map[string]map[string]downloads.Info{"csv": {downloads.VariantDefault: infoWithPrivateURL(testPrivateCsvS3Key)}},
+		Available:   map[string]downloads.Info{"csv": infoWithPrivateURL(testPrivateCsvS3Key)},
 	}
 
 	publishedImageDownloadPrivateURL = downloads.Model{
 		IsPublished: true,
-		Available:   map[string]map[string]downloads.Info{"png": {"1280x720": infoWithPrivateURL(testPrivatePngS3Key)}},
+		Available:   map[string]downloads.Info{"1280x720": infoWithPrivateURL(testPrivatePngS3Key)},
 	}
 
 	unpublishedDatasetDownloadPrivateLink = downloads.Model{
 		IsPublished: false,
-		Available:   map[string]map[string]downloads.Info{"csv": {downloads.VariantDefault: infoWithPrivateURL(testPrivateCsvS3Key)}},
+		Available:   map[string]downloads.Info{"csv": infoWithPrivateURL(testPrivateCsvS3Key)},
 	}
 
 	unpublishedImageDownloadPrivateLink = downloads.Model{
 		IsPublished: false,
-		Available:   map[string]map[string]downloads.Info{"png": {"1280x720": infoWithPrivateURL(testPrivatePngS3Key)}},
+		Available:   map[string]downloads.Info{"1280x720": infoWithPrivateURL(testPrivatePngS3Key)},
 	}
 
 	publishedDatasetDownloadNoURLs = downloads.Model{
 		IsPublished: true,
-		Available:   map[string]map[string]downloads.Info{"csv": {downloads.VariantDefault: infoWithNoURLs()}},
+		Available:   map[string]downloads.Info{"csv": {}},
 	}
 
 	publishedImageDownloadNoURLs = downloads.Model{
 		IsPublished: true,
-		Available:   map[string]map[string]downloads.Info{"png": {"1280x720": infoWithNoURLs()}},
+		Available:   map[string]downloads.Info{"1280x720": {}},
 	}
 
 	publishedDatasetDownloadInvalidPrivateURL = downloads.Model{
 		IsPublished: true,
-		Available:   map[string]map[string]downloads.Info{"csv": {downloads.VariantDefault: infoWithInvalidPrivateURL()}},
+		Available:   map[string]downloads.Info{"csv": infoWithInvalidPrivateURL()},
 	}
 
 	publishedImageDownloadInvalidPrivateURL = downloads.Model{
 		IsPublished: true,
-		Available:   map[string]map[string]downloads.Info{"png": {"1280x720": infoWithInvalidPrivateURL()}},
+		Available:   map[string]downloads.Info{"1280x720": infoWithInvalidPrivateURL()},
 	}
 )
 


### PR DESCRIPTION
### What

- Upgraded to latest dp-api-clients-go to incorporate the flat downloads model for image API
- Flattened generic Download Model (the nested key was only necessary for image API anyway)
- Use Href value as public redirection URL for published/completed images, instead of the old public field
- Simplified generic Info model to only define `Public` and `Private`, as this is the only information required by download  service, and made the mapping between specific models and Info model explicit for all file types.

### How to review

- Make sure changes make sense
- Unit tests should pass

### Who can review

Anyone