### PR TITLE
Add content disposition header to streamed files

### DIFF
--- a/handlers/download.go
+++ b/handlers/download.go
@@ -3,10 +3,12 @@ package handlers
 import (
 	"context"
 	"errors"
-	"github.com/ONSdigital/go-ns/common"
 	"io"
 	"net/http"
 	"net/url"
+	"path"
+
+	"github.com/ONSdigital/go-ns/common"
 
 	"github.com/ONSdigital/dp-download-service/downloads"
 	dphandlers "github.com/ONSdigital/dp-net/handlers"
@@ -142,6 +144,8 @@ func (d Download) do(w http.ResponseWriter, req *http.Request, fileType download
 
 			filename := privateURL.Path
 			logData["filename"] = filename
+
+			w.Header().Set("Content-Disposition", "attachment; filename="+path.Base(filename))
 
 			err = d.S3Content.StreamAndWrite(ctx, filename, w)
 			if err != nil {

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -262,28 +262,7 @@ func TestDownloadDoReturnsOK(t *testing.T) {
 		r.HandleFunc("/downloads/datasets/{datasetID}/editions/{edition}/versions/{version}.csv", d.DoDatasetVersion("csv", mockServiceAuthToken, mockDownloadToken))
 		r.ServeHTTP(w, req)
 
-		So(w.Code, ShouldEqual, http.StatusOK)
-		So(w.Body.Bytes(), ShouldResemble, testCsvContent)
-	})
-
-	Convey("Given a private link to the dataset download exists and the dataset is published then the file content is written to the response body", t, func() {
-		req := httptest.NewRequest("GET", "http://localhost:28000/downloads/datasets/12345/editions/6789/versions/1.csv", nil)
-		w := httptest.NewRecorder()
-		r := mux.NewRouter()
-
-		params := downloads.Parameters{DatasetID: "12345", Edition: "6789", Version: "1"}
-
-		dl := downloaderReturnsResult(mockCtrl, params, downloads.TypeDatasetVersion, publishedDatasetDownloadPrivateURL)
-		s3C := s3ContentWriterSuccessfullyWritesToResponse(mockCtrl, w, testPrivateCsvS3Key, testCsvContent)
-
-		d := Download{
-			Downloader: dl,
-			S3Content:  s3C,
-		}
-
-		r.HandleFunc("/downloads/datasets/{datasetID}/editions/{edition}/versions/{version}.csv", d.DoDatasetVersion("csv", mockServiceAuthToken, mockDownloadToken))
-		r.ServeHTTP(w, req)
-
+		So(w.Header().Get("Content-Disposition"), ShouldEqual, "attachment; filename=my-dataset.csv")
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(w.Body.Bytes(), ShouldResemble, testCsvContent)
 	})
@@ -325,6 +304,7 @@ func TestDownloadDoReturnsOK(t *testing.T) {
 
 		chain.ServeHTTP(w, req)
 
+		So(w.Header().Get("Content-Disposition"), ShouldEqual, "attachment; filename=my-dataset.csv")
 		So(w.Code, ShouldEqual, http.StatusOK)
 		So(w.Body.Bytes(), ShouldResemble, testCsvContent)
 	})


### PR DESCRIPTION
- Add content disposition header with filename
- Remove duplicate test

To review:
Try download a CMD dataset xls/csv in preview before this change. It will render in browser (csv) or download with a file name that follows the version e.g. version 2 will be called 2.xlsx

After th change both types should download as a file (rather than render in browser) with the filename in the format full downloads:`{dataset_id}-{edition}-v{version}.{ext}` and filter outputs: `{dataset_id}-{edition}-v{version}-filtered-{datetime}.{ext}`