### PR TITLE
changed vault path for an instance to be {valutPath}/{instanceID}.csv

### DIFF
--- a/content/s3_stream_writer.go
+++ b/content/s3_stream_writer.go
@@ -36,7 +36,7 @@ type S3Client interface {
 	Checker(ctx context.Context, check *healthcheck.CheckState) error
 }
 
-//S3StreamWriter provides functionality for retrieving content from an S3 bucket. The content is streamed/decrypted and and written to the provided io.Writer
+// S3StreamWriter provides functionality for retrieving content from an S3 bucket. The content is streamed/decrypted and and written to the provided io.Writer
 type S3StreamWriter struct {
 	VaultCli           VaultClient
 	VaultPath          string
@@ -44,7 +44,7 @@ type S3StreamWriter struct {
 	EncryptionDisabled bool
 }
 
-//NewStreamWriter create a new S3StreamWriter instance.
+// NewStreamWriter create a new S3StreamWriter instance.
 func NewStreamWriter(s3c S3Client, vc VaultClient, vp string, encDisabled bool) *S3StreamWriter {
 	return &S3StreamWriter{
 		S3Client:           s3c,
@@ -54,7 +54,7 @@ func NewStreamWriter(s3c S3Client, vc VaultClient, vp string, encDisabled bool) 
 	}
 }
 
-//StreamAndWrite decrypt and stream the request file writing the content to the provided io.Writer.
+// StreamAndWrite decrypt and stream the request file writing the content to the provided io.Writer.
 func (s S3StreamWriter) StreamAndWrite(ctx context.Context, s3Path string, vaultPath string, w io.Writer) (err error) {
 	var s3ReadCloser io.ReadCloser
 	if s.EncryptionDisabled {
@@ -74,7 +74,7 @@ func (s S3StreamWriter) StreamAndWrite(ctx context.Context, s3Path string, vault
 		}
 	}
 
-	defer close(ctx, s3ReadCloser)
+	defer closeAndLogError(ctx, s3ReadCloser)
 
 	_, err = io.Copy(w, s3ReadCloser)
 	if err != nil {
@@ -103,7 +103,7 @@ func (s *S3StreamWriter) getVaultKeyForFile(secretPath string) ([]byte, error) {
 	return psk, nil
 }
 
-func close(ctx context.Context, closer io.Closer) {
+func closeAndLogError(ctx context.Context, closer io.Closer) {
 	if err := closer.Close(); err != nil {
 		log.Error(ctx, "error closing io.Closer", err)
 	}

--- a/downloads/downloader.go
+++ b/downloads/downloader.go
@@ -234,11 +234,11 @@ func (m Model) IsPublicLinkAvailable() bool {
 }
 
 func parseURL(urlString string) (path string, filename string, err error) {
-	url, err := url.Parse(urlString)
+	parsedUrl, err := url.Parse(urlString)
 	if err != nil {
 		return
 	}
-	path = strings.TrimLeft(url.Path, "/")
-	filename = filepath.Base(url.Path)
+	path = strings.TrimLeft(parsedUrl.Path, "/")
+	filename = filepath.Base(parsedUrl.Path)
 	return
 }

--- a/downloads/downloader.go
+++ b/downloads/downloader.go
@@ -168,7 +168,7 @@ func (d Downloader) getInstanceDownload(ctx context.Context, p Parameters, exten
 		filename := fmt.Sprintf("%s.%s", p.InstanceID, extension)
 		model.Public = v.Public
 		model.PrivateS3Path = privatePath
-		model.PrivateVaultPath = privatePath
+		model.PrivateVaultPath = filename
 		model.PrivateFilename = filename
 	}
 

--- a/downloads/downloader_instance_test.go
+++ b/downloads/downloader_instance_test.go
@@ -67,7 +67,7 @@ func TestGetDownloadForInstance(t *testing.T) {
 		So(downloads.Public, ShouldResemble, testCSVPublicUrl)
 		So(downloads.PrivateFilename, ShouldResemble, "instanceID.csv")
 		So(downloads.PrivateS3Path, ShouldResemble, "instances/instanceID.csv")
-		So(downloads.PrivateVaultPath, ShouldResemble, "instances/instanceID.csv")
+		So(downloads.PrivateVaultPath, ShouldResemble, "instanceID.csv")
 		So(err, ShouldBeNil)
 	})
 
@@ -114,7 +114,7 @@ func TestGetDownloadForInstance(t *testing.T) {
 		So(downloads.Public, ShouldResemble, testCSVPublicUrl)
 		So(downloads.PrivateFilename, ShouldResemble, "instanceID.csv")
 		So(downloads.PrivateS3Path, ShouldResemble, "instances/instanceID.csv")
-		So(downloads.PrivateVaultPath, ShouldResemble, "instances/instanceID.csv")
+		So(downloads.PrivateVaultPath, ShouldResemble, "instanceID.csv")
 		So(err, ShouldBeNil)
 	})
 }


### PR DESCRIPTION
### What

Bugfix - Cantabular imports can't generate encrypted CSV files at the moment due to a 'Forbidden' vault path being used.
In this task the path is changed to `{valutPath}/{instanceID}.csv`, so it will be consistent with existing paths for dataset version files.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- The vault path should match the value defined in [Cantabular CSV exporter service](https://github.com/ONSdigital/dp-cantabular-csv-exporter/pull/26)

### Who can review

anyone