### PR TITLE
Feature/add txt endpoint

### DIFF
--- a/content/s3_stream_writer.go
+++ b/content/s3_stream_writer.go
@@ -3,7 +3,6 @@ package content
 import (
 	"context"
 	"fmt"
-	"strings"
 	"encoding/hex"
 	"errors"
 	"io"

--- a/content/s3_stream_writer.go
+++ b/content/s3_stream_writer.go
@@ -69,7 +69,7 @@ func (s S3StreamWriter) StreamAndWrite(ctx context.Context, s3Path string, vault
 			return fmt.Errorf("failed to get Vault key: %w", err)
 		}
 
-		s3ReadCloser, _, err = s.S3Client.GetWithPSK("datasets/cantabular-example-1-2021-1.csv", psk)
+		s3ReadCloser, _, err = s.S3Client.GetWithPSK(s3Path, psk)
 		if err != nil {
 			return fmt.Errorf("failed to get stream object (encrypted) from S3 client: %w", err)
 		}

--- a/content/s3_stream_writer.go
+++ b/content/s3_stream_writer.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"context"
+	"fmt"
 	"encoding/hex"
 	"errors"
 	"io"
@@ -60,17 +61,17 @@ func (s S3StreamWriter) StreamAndWrite(ctx context.Context, s3Path string, vault
 	if s.EncryptionDisabled {
 		s3ReadCloser, _, err = s.S3Client.Get(s3Path)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get stream object from S3 client: %w", err)
 		}
 	} else {
 		psk, err := s.getVaultKeyForFile(vaultPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get Vault key: %w", err)
 		}
 
-		s3ReadCloser, _, err = s.S3Client.GetWithPSK(s3Path, psk)
+		s3ReadCloser, _, err = s.S3Client.GetWithPSK("datasets/cantabular-example-1-2021-1.csv", psk)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get stream object (encrypted) from S3 client: %w", err)
 		}
 	}
 
@@ -78,7 +79,7 @@ func (s S3StreamWriter) StreamAndWrite(ctx context.Context, s3Path string, vault
 
 	_, err = io.Copy(w, s3ReadCloser)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to write response: %w", err)
 	}
 
 	return nil
@@ -92,12 +93,12 @@ func (s *S3StreamWriter) getVaultKeyForFile(secretPath string) ([]byte, error) {
 	vp := s.VaultPath + "/" + secretPath
 	pskStr, err := s.VaultCli.ReadKey(vp, vaultKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read Vault key: %w", err)
 	}
 
 	psk, err := hex.DecodeString(pskStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode psk: %w", err)
 	}
 
 	return psk, nil

--- a/content/s3_stream_writer.go
+++ b/content/s3_stream_writer.go
@@ -3,6 +3,7 @@ package content
 import (
 	"context"
 	"fmt"
+	"strings"
 	"encoding/hex"
 	"errors"
 	"io"

--- a/content/s3_stream_writer_test.go
+++ b/content/s3_stream_writer_test.go
@@ -41,7 +41,7 @@ func TestStreamWriter_WriteContent(t *testing.T) {
 
 		err := s.StreamAndWrite(nil, "", "", w)
 
-		So(err, ShouldEqual, VaultFilenameEmptyErr)
+		So(errors.Is(err, VaultFilenameEmptyErr), ShouldBeTrue)
 	})
 
 	Convey("should return expected error if vault client read key returns and error", t, func() {
@@ -55,7 +55,7 @@ func TestStreamWriter_WriteContent(t *testing.T) {
 
 		err := s.StreamAndWrite(nil, testS3Path, testVaultKeyPath, w)
 
-		So(err, ShouldEqual, expectedErr)
+		So(errors.Is(err, expectedErr), ShouldBeTrue)
 	})
 
 	Convey("should return expected error if vault client read key returns non hex value", t, func() {
@@ -85,7 +85,7 @@ func TestStreamWriter_WriteContent(t *testing.T) {
 
 		err := s.StreamAndWrite(nil, testS3Path, testVaultKeyPath, w)
 
-		So(err, ShouldEqual, expectedErr)
+		So(errors.Is(err, expectedErr), ShouldBeTrue)
 	})
 
 	Convey("should return expected error if s3 client Get returns an error when encryption disabled", t, func() {
@@ -102,7 +102,7 @@ func TestStreamWriter_WriteContent(t *testing.T) {
 
 		err := s.StreamAndWrite(nil, testS3Path, testVaultKeyPath, w)
 
-		So(err, ShouldEqual, expectedErr)
+		So(errors.Is(err, expectedErr), ShouldBeTrue)
 	})
 
 	Convey("should return expected error if s3reader returns an error", t, func() {
@@ -119,7 +119,7 @@ func TestStreamWriter_WriteContent(t *testing.T) {
 
 		err := s.StreamAndWrite(nil, testS3Path, testVaultKeyPath, w)
 
-		So(err, ShouldEqual, expectedErr)
+		So(errors.Is(err, expectedErr), ShouldBeTrue)
 	})
 
 	Convey("should return expected error if writer.write returns an error", t, func() {
@@ -136,7 +136,7 @@ func TestStreamWriter_WriteContent(t *testing.T) {
 
 		err := s.StreamAndWrite(nil, testS3Path, testVaultKeyPath, w)
 
-		So(err, ShouldEqual, expectedErr)
+		So(errors.Is(err, expectedErr), ShouldBeTrue)
 	})
 
 	Convey("should successfully write bytes from s3Reader to the provided writer", t, func() {
@@ -206,7 +206,7 @@ func Test_GetVaultKeyForFile(t *testing.T) {
 
 		So(psk, ShouldBeNil)
 		So(err, ShouldNotBeNil)
-		So(err, ShouldEqual, expectedErr)
+		So(errors.Is(err, expectedErr), ShouldBeTrue)
 	})
 
 	Convey("should return expected error if the vault key cannot be hex decoded", t, func() {

--- a/handlers/callback.go
+++ b/handlers/callback.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"errors"
+	"github.com/ONSdigital/log.go/v2/log"
+	"net/http"
+)
+
+type coder interface {
+	Code() int
+}
+
+type dataLogger interface {
+	LogData() map[string]interface{}
+}
+
+// statusCode is a callback function that allows you to extract
+// a status code from an error, or returns 500 as a default
+func statusCode(err error) int {
+	var cerr coder
+	if errors.As(err, &cerr) {
+		return cerr.Code()
+	}
+
+	return http.StatusInternalServerError
+}
+
+// logData returns logData for an error if there is any. This is used
+// to extract log.Data embedded in an error if it implements the dataLogger
+// interface
+func logData(err error) log.Data {
+	var lderr dataLogger
+	if errors.As(err, &lderr) {
+		return lderr.LogData()
+	}
+
+	return nil
+}
+
+// unwrapLogData recursively unwraps logData from an error. This allows an
+// error to be wrapped with log.Data at each level of the call stack, and
+// then extracted and combined here as a single log.Data entry. This allows
+// us to log errors only once but maintain the context provided by log.Data
+// at each level.
+func unwrapLogData(err error) log.Data {
+	var data []log.Data
+
+	for err != nil && errors.Unwrap(err) != nil {
+		if lderr, ok := err.(dataLogger); ok {
+			if d := lderr.LogData(); d != nil {
+				data = append(data, d)
+			}
+		}
+
+		err = errors.Unwrap(err)
+	}
+
+	// flatten []log.Data into single log.Data with slice
+	// entries for duplicate keyed entries, but not for duplicate
+	// key-value pairs
+	logData := log.Data{}
+	for _, d := range data {
+		for k, v := range d {
+			if val, ok := logData[k]; ok {
+				if val != v {
+					if s, ok := val.([]interface{}); ok {
+						s = append(s, v)
+						logData[k] = s
+					} else {
+						logData[k] = []interface{}{val, v}
+					}
+				}
+			} else {
+				logData[k] = v
+			}
+		}
+	}
+
+	return logData
+}

--- a/handlers/callback_test.go
+++ b/handlers/callback_test.go
@@ -1,0 +1,164 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ONSdigital/log.go/v2/log"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type testError struct {
+	err     error
+	logData map[string]interface{}
+}
+
+// Error implements the Go standard error interface
+func (e *testError) Error() string {
+	if e.err == nil {
+		return "nil"
+	}
+	return e.err.Error()
+}
+
+// LogData implements the DataLogger interface which allows you extract
+// embedded log.Data from an error
+func (e *testError) LogData() map[string]interface{} {
+	if e.logData == nil {
+		return log.Data{}
+	}
+	return e.logData
+}
+
+// Unwrap allows unwrapping an error to access the underlying error
+func (e *testError) Unwrap() error {
+	return e.err
+}
+
+func TestCallbackHappy(t *testing.T) {
+
+	Convey("Given an error with embedded logData", t, func() {
+		err := &testError{
+			logData: log.Data{
+				"log": "data",
+			},
+		}
+
+		Convey("When logData(err) is called", func() {
+			ld := logData(err)
+			So(ld, ShouldResemble, log.Data{"log": "data"})
+		})
+	})
+
+	Convey("Given an error chain with wrapped logData", t, func() {
+		err1 := &testError{
+			err: errors.New("original error"),
+			logData: log.Data{
+				"log": "data",
+			},
+		}
+
+		err2 := &testError{
+			err: fmt.Errorf("err1: %w", err1),
+			logData: log.Data{
+				"additional": "data",
+			},
+		}
+
+		err3 := &testError{
+			err: fmt.Errorf("err2: %w", err2),
+			logData: log.Data{
+				"final": "data",
+			},
+		}
+
+		Convey("When unwrapLogData(err) is called", func() {
+			logData := unwrapLogData(err3)
+			expected := log.Data{
+				"final":      "data",
+				"additional": "data",
+				"log":        "data",
+			}
+
+			So(logData, ShouldResemble, expected)
+		})
+	})
+
+	Convey("Given an error chain with intermittent wrapped logData", t, func() {
+		err1 := &testError{
+			err: errors.New("original error"),
+			logData: log.Data{
+				"log": "data",
+			},
+		}
+
+		err2 := &testError{
+			err: fmt.Errorf("err1: %w", err1),
+		}
+
+		err3 := &testError{
+			err: fmt.Errorf("err2: %w", err2),
+			logData: log.Data{
+				"final": "data",
+			},
+		}
+
+		Convey("When unwrapLogData(err) is called", func() {
+			logData := unwrapLogData(err3)
+			expected := log.Data{
+				"final": "data",
+				"log":   "data",
+			}
+
+			So(logData, ShouldResemble, expected)
+		})
+	})
+
+	Convey("Given an error chain with wrapped logData with duplicate key values", t, func() {
+		err1 := &testError{
+			err: errors.New("original error"),
+			logData: log.Data{
+				"log":        "data",
+				"duplicate":  "duplicate_data1",
+				"request_id": "ADB45F",
+			},
+		}
+
+		err2 := &testError{
+			err: fmt.Errorf("err1: %w", err1),
+			logData: log.Data{
+				"additional": "data",
+				"duplicate":  "duplicate_data2",
+				"request_id": "ADB45F",
+			},
+		}
+
+		err3 := &testError{
+			err: fmt.Errorf("err2: %w", err2),
+			logData: log.Data{
+				"final":      "data",
+				"duplicate":  "duplicate_data3",
+				"request_id": "ADB45F",
+			},
+		}
+
+		Convey("When unwrapLogData(err) is called", func() {
+			logData := unwrapLogData(err3)
+			expected := log.Data{
+				"final":      "data",
+				"additional": "data",
+				"log":        "data",
+				"duplicate": []interface{}{
+					"duplicate_data3",
+					"duplicate_data2",
+					"duplicate_data1",
+				},
+				"request_id": "ADB45F",
+			}
+
+			So(logData, ShouldResemble, expected)
+		})
+	})
+}

--- a/handlers/download.go
+++ b/handlers/download.go
@@ -63,7 +63,7 @@ func setStatusCode(ctx context.Context, w http.ResponseWriter, err error, logDat
 
 	logData["setting_response_status"] = status
 	logData["error"] = err.Error()
-	logData["embedded"] = unwrapLogData(err)
+	logData["other"] = unwrapLogData(err)
 
 	log.Info(ctx, "setting status code for an error", logData)
 	if status == http.StatusNotFound {

--- a/handlers/download.go
+++ b/handlers/download.go
@@ -112,9 +112,12 @@ func (d Download) DoFilterOutput(extension, serviceAuthToken, downloadServiceTok
 // Authenticated requests will always allow access to the private, whether or not the version is published.
 func (d Download) do(w http.ResponseWriter, req *http.Request, fileType downloads.FileType, params downloads.Parameters, variant string) {
 	ctx := req.Context()
+
 	cfg, err := config.Get() 
 	if err != nil{
+		// cfg not used in production codepath so warning will suffice
 		log.Warn(ctx, "failed to get config", log.Data{})
+		cfg = &config.Config{}
 	}
 
 	logData := downloadParametersToLogData(params)

--- a/handlers/download_test.go
+++ b/handlers/download_test.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	testError        = errors.New("borked")
+	testErr        = errors.New("borked")
 	testCsvContent   = []byte("1,2,3,4")
 	testImageContent = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
 )
@@ -418,7 +418,7 @@ func TestDownloadDoFailureScenarios(t *testing.T) {
 
 		params := downloads.Parameters{DatasetID: "12345", Edition: "6789", Version: "1"}
 
-		dl := downloaderReturningError(mockCtrl, params, downloads.TypeDatasetVersion, testError)
+		dl := downloaderReturningError(mockCtrl, params, downloads.TypeDatasetVersion, testErr)
 		s3C := s3ContentNeverInvoked(mockCtrl)
 
 		d := Download{
@@ -440,7 +440,7 @@ func TestDownloadDoFailureScenarios(t *testing.T) {
 
 		params := downloads.Parameters{ImageID: "54321", Variant: "1280x720", Filename: "myImage.png"}
 
-		dl := downloaderReturningError(mockCtrl, params, downloads.TypeImage, testError)
+		dl := downloaderReturningError(mockCtrl, params, downloads.TypeImage, testErr)
 		s3C := s3ContentNeverInvoked(mockCtrl)
 
 		d := Download{
@@ -463,7 +463,7 @@ func TestDownloadDoFailureScenarios(t *testing.T) {
 		params := downloads.Parameters{DatasetID: "12345", Edition: "6789", Version: "1"}
 
 		dl := downloaderReturnsResult(mockCtrl, params, downloads.TypeDatasetVersion, publishedDatasetDownloadPrivateURL)
-		s3C := s3ContentReturnsAnError(mockCtrl, testError)
+		s3C := s3ContentReturnsAnError(mockCtrl, testErr)
 
 		d := Download{
 			Downloader: dl,
@@ -485,7 +485,7 @@ func TestDownloadDoFailureScenarios(t *testing.T) {
 		params := downloads.Parameters{ImageID: "54321", Variant: "1280x720", Filename: "myImage.png"}
 
 		dl := downloaderReturnsResult(mockCtrl, params, downloads.TypeImage, publishedImageDownloadPrivateURL)
-		s3C := s3ContentReturnsAnError(mockCtrl, testError)
+		s3C := s3ContentReturnsAnError(mockCtrl, testErr)
 
 		d := Download{
 			Downloader: dl,

--- a/service/external/external.go
+++ b/service/external/external.go
@@ -7,14 +7,17 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-api-clients-go/v2/image"
+
 	"github.com/ONSdigital/dp-download-service/config"
 	"github.com/ONSdigital/dp-download-service/content"
 	"github.com/ONSdigital/dp-download-service/downloads"
 	"github.com/ONSdigital/dp-download-service/mongo"
 	"github.com/ONSdigital/dp-download-service/service"
-	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+
 	s3client "github.com/ONSdigital/dp-s3"
 	vault "github.com/ONSdigital/dp-vault"
+	"github.com/ONSdigital/dp-healthcheck/healthcheck"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -54,14 +57,14 @@ func (*External) S3Client(cfg *config.Config) (content.S3Client, error) {
 
 		s, err := session.NewSession(s3Config)
 		if err != nil {
-			return nil, fmt.Errorf("could not create the local-object-store s3 client: %w", err)
+			return nil, fmt.Errorf("could not create s3 session: %w", err)
 		}
 		return s3client.NewClientWithSession(cfg.BucketName, s), nil
 	}
 
 	s3, err := s3client.NewClient(cfg.AwsRegion, cfg.BucketName)
 	if err != nil {
-		return nil, fmt.Errorf("could not create the s3 client: %w", err)
+		return nil, fmt.Errorf("could not create s3 client: %w", err)
 	}
 
 	return s3, nil

--- a/service/service.go
+++ b/service/service.go
@@ -159,6 +159,7 @@ func New(ctx context.Context, buildTime, gitCommit, version string, cfg *config.
 	router.Path("/downloads/instances/{instanceID}.csv").HandlerFunc(d.DoInstance("csv", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/downloads/datasets/{datasetID}/editions/{edition}/versions/{version}.csv").HandlerFunc(d.DoDatasetVersion("csv", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/downloads/datasets/{datasetID}/editions/{edition}/versions/{version}.csv-metadata.json").HandlerFunc(d.DoDatasetVersion("csvw", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
+	router.Path("/downloads/datasets/{datasetID}/editions/{edition}/versions/{version}.txt").HandlerFunc(d.DoDatasetVersion("txt", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/downloads/datasets/{datasetID}/editions/{edition}/versions/{version}.xlsx").HandlerFunc(d.DoDatasetVersion("xls", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/downloads/filter-outputs/{filterOutputID}.csv").HandlerFunc(d.DoFilterOutput("csv", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/downloads/filter-outputs/{filterOutputID}.xlsx").HandlerFunc(d.DoFilterOutput("xls", cfg.ServiceAuthToken, cfg.DownloadServiceToken))


### PR DESCRIPTION
### What

Add endpoint for download .txt files (for Cantabular .txt metatada)
Improve errors and logging throughout
Fix s3 path for when using local minio storage

### How to review

Check code makes sense
Optional: Run Cantabular import journey, import dataset and attach to collection. Check downloads work for files: csv, csvw and txt

### Who can review

Anyone
