### PR TITLE
Redirect when decrypted published

### DIFF
--- a/api/download.go
+++ b/api/download.go
@@ -2,17 +2,17 @@ package api
 
 import (
 	"fmt"
+	"github.com/ONSdigital/dp-download-service/config"
 	"github.com/ONSdigital/dp-download-service/files"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 	"io"
 	"net/http"
-	"net/url"
 	"path"
 )
 
 // DoDownload handles download generic file requests.
-func CreateV1DownloadHandler(fetchMetadata files.MetadataFetcher, downloadFile files.FileDownloader, publicBucketURL string) http.HandlerFunc {
+func CreateV1DownloadHandler(fetchMetadata files.MetadataFetcher, downloadFile files.FileDownloader, publicBucketURL config.ConfigUrl) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		filePath := mux.Vars(req)["path"]
 
@@ -24,16 +24,8 @@ func CreateV1DownloadHandler(fetchMetadata files.MetadataFetcher, downloadFile f
 
 		if metadata.Decrypted() {
 			log.Info(req.Context(), "File already decrypted, redirecting")
-			parsedURL, err := url.Parse(publicBucketURL)
-
-			if err != nil {
-				log.Error(req.Context(), fmt.Sprintf("Bad public bucket url: %s", publicBucketURL), err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-
-			parsedURL.Path = path.Join(filePath)
-			w.Header().Set("Location", parsedURL.String())
+			publicBucketURL.Path = path.Join(filePath)
+			w.Header().Set("Location", publicBucketURL.String())
 			w.WriteHeader(http.StatusMovedPermanently)
 			return
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	DatasetAuthToken           string        `envconfig:"DATASET_AUTH_TOKEN"         json:"-"`
 	FilterAPIURL               string        `envconfig:"FILTER_API_URL"`
 	ImageAPIURL                string        `envconfig:"IMAGE_API_URL"`
-	FilesApiURL                string		 `envconfig:"FILES_API_URL"`
+	FilesApiURL                string        `envconfig:"FILES_API_URL"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"  json:"-"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -31,6 +31,7 @@ type Config struct {
 	MinioSecretKey             string        `envconfig:"MINIO_SECRET_KEY"`   // TODO remove replacing minio with localstack in component tests
 	IsPublishing               bool          `envconfig:"IS_PUBLISHING"`
 	EncryptionDisabled         bool          `envconfig:"ENCRYPTION_DISABLED"` // TODO remove encryption always required
+	PublicBucketURL            string        `envconfig:"PUBLIC_BUCKET_URL"`
 }
 
 var cfg *Config
@@ -64,6 +65,7 @@ func Get() (*Config, error) {
 		MinioSecretKey:             "",
 		IsPublishing:               true,
 		EncryptionDisabled:         false,
+		PublicBucketURL:            "http://public-bucket.com/",
 	}
 
 	if err := envconfig.Process("", cfg); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/kelseyhightower/envconfig"
 	"net/url"
 	"os"
 	"testing"
@@ -59,7 +60,8 @@ func TestSpec(t *testing.T) {
 
 		os.Setenv("PUBLIC_BUCKET_URL", "http://test")
 
-		cfg, err := Get()
+
+		config, err := Get()
 
 		Convey("when the config variables are retrieved", func() {
 
@@ -68,29 +70,50 @@ func TestSpec(t *testing.T) {
 			})
 
 			Convey("the values should be set to the expected defaults", func() {
-				So(cfg.BindAddr, ShouldEqual, "localhost:23600")
-				So(cfg.BucketName, ShouldEqual, "csv-exported")
-				So(cfg.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
-				So(cfg.DatasetAuthToken, ShouldEqual, "FD0108EA-825D-411C-9B1D-41EF7727F465")
-				So(cfg.DownloadServiceToken, ShouldEqual, "QB0108EZ-825D-412C-9B1D-41EF7747F462")
-				So(cfg.FilterAPIURL, ShouldEqual, "http://localhost:22100")
-				So(cfg.ImageAPIURL, ShouldEqual, "http://localhost:24700")
-				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
-				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
-				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
-				So(cfg.VaultToken, ShouldEqual, "")
-				So(cfg.VaultPath, ShouldEqual, "secret/shared/psk")
-				So(cfg.ServiceAuthToken, ShouldEqual, "c60198e9-1864-4b68-ad0b-1e858e5b46a4")
-				So(cfg.ZebedeeURL, ShouldEqual, "http://localhost:8082")
-				So(cfg.LocalObjectStore, ShouldEqual, "")
-				So(cfg.MinioAccessKey, ShouldEqual, "")
-				So(cfg.MinioSecretKey, ShouldEqual, "")
-				So(cfg.IsPublishing, ShouldBeTrue)
-				So(cfg.EncryptionDisabled, ShouldBeFalse)
+				So(config.BindAddr, ShouldEqual, "localhost:23600")
+				So(config.BucketName, ShouldEqual, "csv-exported")
+				So(config.DatasetAPIURL, ShouldEqual, "http://localhost:22000")
+				So(config.DatasetAuthToken, ShouldEqual, "FD0108EA-825D-411C-9B1D-41EF7727F465")
+				So(config.DownloadServiceToken, ShouldEqual, "QB0108EZ-825D-412C-9B1D-41EF7747F462")
+				So(config.FilterAPIURL, ShouldEqual, "http://localhost:22100")
+				So(config.ImageAPIURL, ShouldEqual, "http://localhost:24700")
+				So(config.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
+				So(config.HealthCheckInterval, ShouldEqual, 30*time.Second)
+				So(config.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
+				So(config.VaultToken, ShouldEqual, "")
+				So(config.VaultPath, ShouldEqual, "secret/shared/psk")
+				So(config.ServiceAuthToken, ShouldEqual, "c60198e9-1864-4b68-ad0b-1e858e5b46a4")
+				So(config.ZebedeeURL, ShouldEqual, "http://localhost:8082")
+				So(config.LocalObjectStore, ShouldEqual, "")
+				So(config.MinioAccessKey, ShouldEqual, "")
+				So(config.MinioSecretKey, ShouldEqual, "")
+				So(config.IsPublishing, ShouldBeTrue)
+				So(config.EncryptionDisabled, ShouldBeFalse)
 
 				expectedUrl, _ := url.Parse("http://test")
-				So(cfg.PublicBucketURL, ShouldResemble, ConfigUrl{*expectedUrl})
+				So(config.PublicBucketURL, ShouldResemble, ConfigUrl{*expectedUrl})
 			})
+		})
+	})
+}
+
+func TestBadPublicBucketUrl(t *testing.T) {
+	Convey("Given an environment variable with a bad public-bucket url", t, func() {
+		originalConfigEnv := getConfigEnv()
+		defer setConfigEnv(originalConfigEnv)
+
+		for k := range originalConfigEnv {
+			os.Unsetenv(k)
+		}
+
+		os.Setenv("PUBLIC_BUCKET_URL", "://test")
+
+		cfg = nil
+
+		_, err := Get()
+
+		Convey("getting config values should result in parse error", func() {
+			So(err, ShouldHaveSameTypeAs, &envconfig.ParseError{})
 		})
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -36,6 +37,7 @@ func getConfigEnv() map[string]string {
 		"MONGODB_USERNAME":             os.Getenv("MONGODB_USERNAME"),
 		"MONGODB_PASSWORD":             os.Getenv("MONGODB_PASSWORD"),
 		"MONGODB_IS_SSL":               os.Getenv("MONGODB_IS_SSL"),
+		"PUBLIC_BUCKET_URL":            os.Getenv("PUBLIC_BUCKET_URL"),
 	}
 }
 
@@ -54,6 +56,8 @@ func TestSpec(t *testing.T) {
 		for k := range originalConfigEnv {
 			os.Unsetenv(k)
 		}
+
+		os.Setenv("PUBLIC_BUCKET_URL", "http://test")
 
 		cfg, err := Get()
 
@@ -83,6 +87,9 @@ func TestSpec(t *testing.T) {
 				So(cfg.MinioSecretKey, ShouldEqual, "")
 				So(cfg.IsPublishing, ShouldBeTrue)
 				So(cfg.EncryptionDisabled, ShouldBeFalse)
+
+				expectedUrl, _ := url.Parse("http://test")
+				So(cfg.PublicBucketURL, ShouldResemble, ConfigUrl{*expectedUrl})
 			})
 		})
 	})

--- a/features/health.feature
+++ b/features/health.feature
@@ -1,6 +1,6 @@
-#Feature: Health check
-#
-#  Scenario:
-#    When I GET "/health"
-#    Then the HTTP status code should be "200"
-#
+Feature: Health check
+
+  Scenario:
+    When I GET "/health"
+    Then the HTTP status code should be "200"
+

--- a/features/health.feature
+++ b/features/health.feature
@@ -1,6 +1,6 @@
-Feature: Health check
-
-  Scenario:
-    When I GET "/health"
-    Then the HTTP status code should be "200"
-
+#Feature: Health check
+#
+#  Scenario:
+#    When I GET "/health"
+#    Then the HTTP status code should be "200"
+#

--- a/features/ons_website_download.feature
+++ b/features/ons_website_download.feature
@@ -65,3 +65,25 @@ Feature: ONS Public Website Download files
         """
     When I download the file "data/populations.csv"
     Then the HTTP status code should be "404"
+
+  Scenario: Redirecting public to decrypted bucket when file is published & decrypted
+      Given the file "data/populations.csv" has been uploaded
+        """
+        {
+          "path": "data/populations.csv",
+          "is_publishable": true,
+          "collection_id": "1234-asdfg-54321-qwerty",
+          "title": "The number of people",
+          "size_in_bytes": 29,
+          "type": "text/csv",
+          "licence": "OGL v3",
+          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+          "state": "DECRYPTED"
+        }
+        """
+      And the file "data/populations.csv" encrypted using key "1234567891234567" from Vault stored in S3 with content:
+        """
+        mark,1
+        """
+      When I download the file "data/populations.csv"
+      Then I should be redirected to "http://some-aws-s3/data/populations.csv"

--- a/features/ons_website_download.feature
+++ b/features/ons_website_download.feature
@@ -3,68 +3,68 @@ Feature: ONS Public Website Download files
   Background:
     Given we are in web mode
 
-  Scenario: Download a file that has been published
-    Given the file "data/populations.csv" metadata:
-        """
-        {
-          "path": "data/populations.csv",
-          "is_publishable": true,
-          "collection_id": "1234-asdfg-54321-qwerty",
-          "title": "The number of people",
-          "size_in_bytes": 29,
-          "type": "text/csv",
-          "licence": "OGL v3",
-          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-          "state": "PUBLISHED"
-        }
-        """
-    And the file "data/populations.csv" encrypted using key "1234567891234567" from Vault stored in S3 with content:
-        """
-        mark,1
-        jon,2
-        russ,3
-        Ioannis,4
-        """
-    When I download the file "data/populations.csv"
-    Then the HTTP status code should be "200"
-    And the headers should be:
-      | Content-Type        | application/octet-stream             |
-      | Content-Length      | 29                                   |
-      | Content-Disposition | attachment; filename=populations.csv |
-    And the file content should be:
-      """
-      mark,1
-      jon,2
-      russ,3
-      Ioannis,4
-      """
-
-  Scenario: Trying to download a file that has not been uploaded yet
-    Given the file "data/populations.csv" has not been uploaded
-    When I download the file "data/populations.csv"
-    Then the HTTP status code should be "404"
-
-  Scenario: ONS previewer requests data-file that has been uploaded but not yet published
-    Given the file "data/populations.csv" has been uploaded
-        """
-        {
-          "path": "data/populations.csv",
-          "is_publishable": true,
-          "collection_id": "1234-asdfg-54321-qwerty",
-          "title": "The number of people",
-          "size_in_bytes": 29,
-          "type": "text/csv",
-          "licence": "OGL v3",
-          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-          "state": "UPLOADED"
-        }
-        """
-    And the S3 file "data/populations.csv" with content:
-        """
-        mark,1
-        """
-    When I download the file "data/populations.csv"
-    Then the HTTP status code should be "404"
+#  Scenario: Download a file that has been published
+#    Given the file "data/populations.csv" metadata:
+#        """
+#        {
+#          "path": "data/populations.csv",
+#          "is_publishable": true,
+#          "collection_id": "1234-asdfg-54321-qwerty",
+#          "title": "The number of people",
+#          "size_in_bytes": 29,
+#          "type": "text/csv",
+#          "licence": "OGL v3",
+#          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+#          "state": "PUBLISHED"
+#        }
+#        """
+#    And the file "data/populations.csv" encrypted using key "1234567891234567" from Vault stored in S3 with content:
+#        """
+#        mark,1
+#        jon,2
+#        russ,3
+#        Ioannis,4
+#        """
+#    When I download the file "data/populations.csv"
+#    Then the HTTP status code should be "200"
+#    And the headers should be:
+#      | Content-Type        | application/octet-stream             |
+#      | Content-Length      | 29                                   |
+#      | Content-Disposition | attachment; filename=populations.csv |
+#    And the file content should be:
+#      """
+#      mark,1
+#      jon,2
+#      russ,3
+#      Ioannis,4
+#      """
+#
+#  Scenario: Trying to download a file that has not been uploaded yet
+#    Given the file "data/populations.csv" has not been uploaded
+#    When I download the file "data/populations.csv"
+#    Then the HTTP status code should be "404"
+#
+#  Scenario: ONS previewer requests data-file that has been uploaded but not yet published
+#    Given the file "data/populations.csv" has been uploaded
+#        """
+#        {
+#          "path": "data/populations.csv",
+#          "is_publishable": true,
+#          "collection_id": "1234-asdfg-54321-qwerty",
+#          "title": "The number of people",
+#          "size_in_bytes": 29,
+#          "type": "text/csv",
+#          "licence": "OGL v3",
+#          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+#          "state": "UPLOADED"
+#        }
+#        """
+#    And the S3 file "data/populations.csv" with content:
+#        """
+#        mark,1
+#        """
+#    When I download the file "data/populations.csv"
+#    Then the HTTP status code should be "404"
 
   Scenario: Redirecting public to decrypted bucket when file is published & decrypted
       Given the file "data/populations.csv" has been uploaded
@@ -86,4 +86,4 @@ Feature: ONS Public Website Download files
         mark,1
         """
       When I download the file "data/populations.csv"
-      Then I should be redirected to "http://some-aws-s3/data/populations.csv"
+      Then I should be redirected to "http://public-bucket.com/data/populations.csv"

--- a/features/ons_website_download.feature
+++ b/features/ons_website_download.feature
@@ -3,68 +3,68 @@ Feature: ONS Public Website Download files
   Background:
     Given we are in web mode
 
-#  Scenario: Download a file that has been published
-#    Given the file "data/populations.csv" metadata:
-#        """
-#        {
-#          "path": "data/populations.csv",
-#          "is_publishable": true,
-#          "collection_id": "1234-asdfg-54321-qwerty",
-#          "title": "The number of people",
-#          "size_in_bytes": 29,
-#          "type": "text/csv",
-#          "licence": "OGL v3",
-#          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-#          "state": "PUBLISHED"
-#        }
-#        """
-#    And the file "data/populations.csv" encrypted using key "1234567891234567" from Vault stored in S3 with content:
-#        """
-#        mark,1
-#        jon,2
-#        russ,3
-#        Ioannis,4
-#        """
-#    When I download the file "data/populations.csv"
-#    Then the HTTP status code should be "200"
-#    And the headers should be:
-#      | Content-Type        | application/octet-stream             |
-#      | Content-Length      | 29                                   |
-#      | Content-Disposition | attachment; filename=populations.csv |
-#    And the file content should be:
-#      """
-#      mark,1
-#      jon,2
-#      russ,3
-#      Ioannis,4
-#      """
-#
-#  Scenario: Trying to download a file that has not been uploaded yet
-#    Given the file "data/populations.csv" has not been uploaded
-#    When I download the file "data/populations.csv"
-#    Then the HTTP status code should be "404"
-#
-#  Scenario: ONS previewer requests data-file that has been uploaded but not yet published
-#    Given the file "data/populations.csv" has been uploaded
-#        """
-#        {
-#          "path": "data/populations.csv",
-#          "is_publishable": true,
-#          "collection_id": "1234-asdfg-54321-qwerty",
-#          "title": "The number of people",
-#          "size_in_bytes": 29,
-#          "type": "text/csv",
-#          "licence": "OGL v3",
-#          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-#          "state": "UPLOADED"
-#        }
-#        """
-#    And the S3 file "data/populations.csv" with content:
-#        """
-#        mark,1
-#        """
-#    When I download the file "data/populations.csv"
-#    Then the HTTP status code should be "404"
+  Scenario: Download a file that has been published
+    Given the file "data/populations.csv" metadata:
+        """
+        {
+          "path": "data/populations.csv",
+          "is_publishable": true,
+          "collection_id": "1234-asdfg-54321-qwerty",
+          "title": "The number of people",
+          "size_in_bytes": 29,
+          "type": "text/csv",
+          "licence": "OGL v3",
+          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+          "state": "PUBLISHED"
+        }
+        """
+    And the file "data/populations.csv" encrypted using key "1234567891234567" from Vault stored in S3 with content:
+        """
+        mark,1
+        jon,2
+        russ,3
+        Ioannis,4
+        """
+    When I download the file "data/populations.csv"
+    Then the HTTP status code should be "200"
+    And the headers should be:
+      | Content-Type        | application/octet-stream             |
+      | Content-Length      | 29                                   |
+      | Content-Disposition | attachment; filename=populations.csv |
+    And the file content should be:
+      """
+      mark,1
+      jon,2
+      russ,3
+      Ioannis,4
+      """
+
+  Scenario: Trying to download a file that has not been uploaded yet
+    Given the file "data/populations.csv" has not been uploaded
+    When I download the file "data/populations.csv"
+    Then the HTTP status code should be "404"
+
+  Scenario: ONS previewer requests data-file that has been uploaded but not yet published
+    Given the file "data/populations.csv" has been uploaded
+        """
+        {
+          "path": "data/populations.csv",
+          "is_publishable": true,
+          "collection_id": "1234-asdfg-54321-qwerty",
+          "title": "The number of people",
+          "size_in_bytes": 29,
+          "type": "text/csv",
+          "licence": "OGL v3",
+          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+          "state": "UPLOADED"
+        }
+        """
+    And the S3 file "data/populations.csv" with content:
+        """
+        mark,1
+        """
+    When I download the file "data/populations.csv"
+    Then the HTTP status code should be "404"
 
   Scenario: Redirecting public to decrypted bucket when file is published & decrypted
       Given the file "data/populations.csv" has been uploaded

--- a/features/steps/download_service_component.go
+++ b/features/steps/download_service_component.go
@@ -53,6 +53,7 @@ func NewDownloadServiceComponent(fake_auth_url string) *DownloadServiceComponent
 	fakeService := httpfake.New()
 	fakeService.NewHandler().Get("/health").Reply(http.StatusOK)
 	os.Setenv("ZEBEDEE_URL", fakeService.ResolveURL(""))
+	os.Setenv("PUBLIC_BUCKET_URL", "http://public-bucket.com/")
 	d.cfg, _ = config.Get()
 
 	d.deps = &External{Server: d.DpHttpServer}

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -154,7 +154,11 @@ func (d *DownloadServiceComponent) theS3FileWithContent(filepath string, content
 }
 
 func (d *DownloadServiceComponent) iShouldBeRedirectedTo(url string) error {
-	return d.ApiFeature.TheHTTPStatusCodeShouldBe("302")
+	d.ApiFeature.TheHTTPStatusCodeShouldBe("301")
+
+	assert.Equal(d.ApiFeature, url, d.ApiFeature.HttpResponse.Header.Get("Location"))
+
+	return d.ApiFeature.StepError()
 }
 
 func encryptObjectContent(psk []byte, b io.Reader) ([]byte, error) {

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -35,6 +35,7 @@ func (d *DownloadServiceComponent) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the file content should be:$`, d.theFileContentShouldBe)
 	ctx.Step(`^the file "([^"]*)" has not been uploaded$`, d.theFileHasNotBeenUploaded)
 	ctx.Step(`^the file "([^"]*)" encrypted using key "([^"]*)" from Vault stored in S3 with content:$`, d.theFileEncryptedUsingKeyFromVaultStoredInSWithContent)
+	ctx.Step(`^I should be redirected to "([^"]*)"$`, d.iShouldBeRedirectedTo)
 
 }
 
@@ -150,6 +151,10 @@ func (d *DownloadServiceComponent) theS3FileWithContent(filepath string, content
 	assert.NoError(d.ApiFeature, err)
 
 	return d.ApiFeature.StepError()
+}
+
+func (d *DownloadServiceComponent) iShouldBeRedirectedTo(url string) error {
+	return d.ApiFeature.TheHTTPStatusCodeShouldBe("302")
 }
 
 func encryptObjectContent(psk []byte, b io.Reader) ([]byte, error) {

--- a/files/metadata.go
+++ b/files/metadata.go
@@ -37,3 +37,7 @@ func (m Metadata) GetContentLength() string {
 func (m Metadata) Unpublished() bool {
 	return m.State == UPLOADED || m.State == CREATED
 }
+
+func (m Metadata) Decrypted() bool {
+	return m.State == DECRYPTED
+}

--- a/service/service.go
+++ b/service/service.go
@@ -142,6 +142,7 @@ func New(ctx context.Context, buildTime, gitCommit, version string, cfg *config.
 	downloadHandler := api.CreateV1DownloadHandler(
 		files.FetchMetadata(cfg.FilesApiURL, http.DefaultClient),
 		files.DownloadFile(svc.s3Client, vc, cfg.VaultPath),
+		cfg.PublicBucketURL,
 	)
 
 	// And tie routes to download hander methods.


### PR DESCRIPTION
### What

Handle case were file is already decrypted and user should be redirected to public-decrypted S3 bucket.

