### PR TITLE
Added Auth header pass-through on downloads

### DIFF
--- a/api/download.go
+++ b/api/download.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	dprequest "github.com/ONSdigital/dp-net/v2/request"
 	"io"
 	"net/http"
 
@@ -51,6 +52,12 @@ func CreateV1DownloadHandler(fetchMetadata files.MetadataFetcher, downloadFileFr
 func parseRequest(req *http.Request) (context.Context, string) {
 	ctx := req.Context()
 	filePath := mux.Vars(req)["path"]
+
+	authHeaderValue := req.Header.Get(dprequest.AuthHeaderKey)
+	if authHeaderValue != "" {
+		const key files.ContextKey = dprequest.AuthHeaderKey
+		ctx = context.WithValue(ctx, key, authHeaderValue)
+	}
 
 	return ctx, filePath
 }

--- a/features/ons_reviewer_downloads_file.feature
+++ b/features/ons_reviewer_downloads_file.feature
@@ -6,7 +6,7 @@ Feature: Download preview feature
         And I am identified as "dave@ons.gov.uk"
 
     Scenario: ONS previewer requests data-file that has been uploaded but not yet published
-        Given the file "data/populations.csv" has been uploaded
+        Given the file "data/populations.csv" has the metadata:
         """
         {
           "path": "data/populations.csv",
@@ -33,8 +33,37 @@ Feature: Download preview feature
         When I download the file "data/populations.csv"
         Then the HTTP status code should be "200"
 
+    Scenario: ONS previewer requests data-file that has been uploaded but not yet published using an authorisation header
+        Given the file "data/authors.csv" has the metadata:
+        """
+        {
+          "path": "data/populations.csv",
+          "is_publishable": true,
+          "collection_id": "1234-asdfg-54321-qwerty",
+          "title": "The number of people",
+          "size_in_bytes": 29,
+          "type": "text/csv",
+          "licence": "OGL v3",
+          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+          "state": "UPLOADED"
+        }
+        """
+        And the file "data/authors.csv" is encrypted in S3 with content:
+        """
+        mark,1
+        russ,2
+        dan,3
+        saul,3.5
+        brian,4
+        jon,5
+        """
+        And I set the "Authorization" header to "auth-header-total-secure"
+        When I download the file "data/authors.csv"
+        Then the HTTP status code should be "200"
+        And the GET request with path ("data/authors.csv") should contain an authorization header containing "auth-header-total-secure"
+
     Scenario: ONS previewer requests data-file with weird characters that has been uploaded but not yet published
-        Given the file "interactives/87a3dde3-wéî®∂-4290-9a3b-afbea82e0fa7/version-11/lib&/chosen-sprite@2x.png" has been uploaded
+        Given the file "interactives/87a3dde3-wéî®∂-4290-9a3b-afbea82e0fa7/version-11/lib&/chosen-sprite@2x.png" has the metadata:
         """
         {
           "path": "interactives/87a3dde3-wéî®∂-4290-9a3b-afbea82e0fa7/version-11/lib&/chosen-sprite@2x.png",

--- a/features/ons_website_download.feature
+++ b/features/ons_website_download.feature
@@ -4,7 +4,7 @@ Feature: ONS Public Website Download files
     Given the application is in "web" mode
 
   Scenario: Download a file that has been published
-    Given the file "data/populations.csv" metadata:
+    Given the file "data/populations.csv" has the metadata:
         """
         {
           "path": "data/populations.csv",
@@ -40,7 +40,7 @@ Feature: ONS Public Website Download files
       """
 
   Scenario: Download a file with weird characters that has been published
-    Given the file "interactives/87a3dde3-wéî®∂-4290-9a3b-afbea82e0fa7/version-11/lib&/chosen-sprite@2x.png" metadata:
+    Given the file "interactives/87a3dde3-wéî®∂-4290-9a3b-afbea82e0fa7/version-11/lib&/chosen-sprite@2x.png" has the metadata:
         """
         {
           "path": "interactives/87a3dde3-wéî®∂-4290-9a3b-afbea82e0fa7/version-11/lib&/chosen-sprite@2x.png",
@@ -81,7 +81,7 @@ Feature: ONS Public Website Download files
     Then the HTTP status code should be "404"
 
   Scenario: ONS previewer requests data-file that has been uploaded but not yet published
-    Given the file "data/populations.csv" has been uploaded
+    Given the file "data/populations.csv" has the metadata:
         """
         {
           "path": "data/populations.csv",
@@ -108,7 +108,7 @@ Feature: ONS Public Website Download files
     Then the HTTP status code should be "404"
 
   Scenario: Redirecting public to decrypted bucket when file is published & decrypted
-    Given the file "data/populations.csv" has been uploaded
+    Given the file "data/populations.csv" has the metadata:
         """
         {
           "path": "data/populations.csv",

--- a/files/retreiver_test.go
+++ b/files/retreiver_test.go
@@ -41,7 +41,7 @@ func newFakeHttpClient(statusCode int, body string) HTTPClient {
 	}
 }
 
-func (f fakeHttpClient) Get(ctx context.Context, url string) (resp *http.Response, err error) {
+func (f fakeHttpClient) Do(ctx context.Context, req *http.Request) (resp *http.Response, err error) {
 	return &http.Response{
 		StatusCode: f.statusCode,
 		Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(f.body))),


### PR DESCRIPTION
### What

Added capture of the auth header in the handler, and using it on calls to the files service
### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
