### PR TITLE
add routes for filter-output .txt and csv-metadata.json

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,0 +1,8 @@
+# The following should be considered as temporary work-arounds
+sonatype-2020-1055
+sonatype-2019-0702
+CVE-2022-29153
+CVE-2022-29153
+sonatype-2021-1401
+sonatype-2019-0890
+CVE-2022-21698

--- a/service/service.go
+++ b/service/service.go
@@ -157,6 +157,8 @@ func New(ctx context.Context, buildTime, gitCommit, version string, cfg *config.
 	router.Path("/downloads/datasets/{datasetID}/editions/{edition}/versions/{version}.xlsx").HandlerFunc(d.DoDatasetVersion("xls", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/downloads/filter-outputs/{filterOutputID}.csv").HandlerFunc(d.DoFilterOutput("csv", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/downloads/filter-outputs/{filterOutputID}.xlsx").HandlerFunc(d.DoFilterOutput("xls", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
+	router.Path("/downloads/filter-outputs/{filterOutputID}.txt").HandlerFunc(d.DoFilterOutput("txt", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
+	router.Path("/downloads/filter-outputs/{filterOutputID}.csv-metadata.json").HandlerFunc(d.DoFilterOutput("csvw", cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/images/{imageID}/{variant}/{filename}").HandlerFunc(d.DoImage(cfg.ServiceAuthToken, cfg.DownloadServiceToken))
 	router.Path("/downloads-new/{path:.*}").HandlerFunc(downloadHandler)
 	router.HandleFunc("/health", hc.Handler)


### PR DESCRIPTION
### What

Added routes for /filter-outputs/{filename}.txt and /filter-outputs/{filename}.csv-metadata.json

### How to review

Check changes make sense

### Who can review

Anyone
