### PR TITLE
feature flag (DO_CORS/DoCors) for addition of CORS-handling middleware

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	IsPublishing               bool          `envconfig:"IS_PUBLISHING"`
 	EncryptionDisabled         bool          `envconfig:"ENCRYPTION_DISABLED"` // TODO remove encryption always required
 	PublicBucketURL            ConfigUrl     `envconfig:"PUBLIC_BUCKET_URL"`
+	DoCors                     bool          `envconfig:"DO_CORS"`
 }
 
 var cfg *Config
@@ -86,6 +87,7 @@ func Get() (*Config, error) {
 		IsPublishing:               true,
 		EncryptionDisabled:         false,
 		PublicBucketURL:            ConfigUrl{},
+		DoCors:                     false,
 	}
 
 	if err := envconfig.Process("", cfg); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,6 +39,7 @@ func getConfigEnv() map[string]string {
 		"MONGODB_PASSWORD":             os.Getenv("MONGODB_PASSWORD"),
 		"MONGODB_IS_SSL":               os.Getenv("MONGODB_IS_SSL"),
 		"PUBLIC_BUCKET_URL":            os.Getenv("PUBLIC_BUCKET_URL"),
+		"DO_CORS":                      os.Getenv("DO_CORS"),
 	}
 }
 
@@ -92,6 +93,7 @@ func TestSpec(t *testing.T) {
 
 				expectedUrl, _ := url.Parse("http://test")
 				So(config.PublicBucketURL, ShouldResemble, ConfigUrl{*expectedUrl})
+				So(config.DoCors, ShouldBeFalse)
 			})
 		})
 	})

--- a/service/service.go
+++ b/service/service.go
@@ -175,8 +175,10 @@ func New(ctx context.Context, buildTime, gitCommit, version string, cfg *config.
 		identityHandler := dphandlers.IdentityWithHTTPClient(clientsidentity.NewWithHealthClient(zc))
 		middlewareChain = middlewareChain.Append(identityHandler)
 	} else {
-		corsHandler := gorillahandlers.CORS(gorillahandlers.AllowedMethods([]string{"GET"}))
-		middlewareChain = middlewareChain.Append(corsHandler)
+		if cfg.DoCors {
+			corsHandler := gorillahandlers.CORS(gorillahandlers.AllowedMethods([]string{"GET"}))
+			middlewareChain = middlewareChain.Append(corsHandler)
+		}
 	}
 
 	r := middlewareChain.


### PR DESCRIPTION
### What

commit 7ae7b7c8c38cdc26181bae8777480e69d165c855 (HEAD -> feat/optional-cors-headers, origin/feat/optional-cors-headers)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Aug 16 13:40:38 2022 +0100

    feature flag (DO_CORS/DoCors) for addition of CORS-handling middleware

    Hide use of CORS middleware behind feature flag DoCors (default is
    false). This change needed to avoid clashes with the CORS handlers
    added by the ONS API router.

### How to review

Steps to reproduce issue locally:
- export DO_CORS='true'and run branch locally, along with API router
- publish file
- fetch the file via the API router, ideally from browser javascript
- you should see that the `Allow-Access-Control-Origin: *` header is duplicated when using the service via the API router (or you see this error if using the browser console: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMultipleAllowOriginNotAllowed)
- export DO_CORS='false' and restart the download service
- fetch the file via the API router again
- you should see that there is only one `Allow-Access-Control-Origin: *` header, and you are able to fetch from the browser with no issues.

### Who can review

Anyone familiar with the service
