### PR TITLE
add limiter middleware

### DIFF
--- a/api/limiter.go
+++ b/api/limiter.go
@@ -1,0 +1,42 @@
+package api
+
+import "net/http"
+
+func Limiter(n int) func(http.Handler) http.Handler {
+	counter := make(chan struct{}, n)
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if n < 1 {
+				h.ServeHTTP(w, r)
+				return
+			}
+			counter <- struct{}{}
+			defer func() { <-counter }()
+
+			h.ServeHTTP(w, r)
+		})
+	}
+}
+
+var n = 5
+
+func LimiterMidd(h http.Handler) http.Handler {
+	counter := make(chan struct{}, n)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter <- struct{}{}
+		defer func() { <-counter }()
+
+		h.ServeHTTP(w, r)
+	})
+}
+
+func LimiterHandler(h http.Handler, n int) http.Handler {
+	counter := make(chan struct{}, n)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter <- struct{}{}
+		defer func() { <-counter }()
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/api/limiter.go
+++ b/api/limiter.go
@@ -2,6 +2,14 @@ package api
 
 import "net/http"
 
+// Limiter is a middleware that makes sure that no more than n handlers
+// are being executed in parallel.
+//
+// If more traffic comes in while all n handlers are running, the Limiter
+// drops the extra requests by returning HTTP status code of 429 (Too Many Requests)
+// and never executing the inner handler.
+//
+// If n is 0, no concurrency limits are applied at all.
 func Limiter(n int) func(http.Handler) http.Handler {
 	counter := make(chan struct{}, n)
 	return func(h http.Handler) http.Handler {
@@ -20,27 +28,4 @@ func Limiter(n int) func(http.Handler) http.Handler {
 			}
 		})
 	}
-}
-
-var n = 5
-
-func LimiterMidd(h http.Handler) http.Handler {
-	counter := make(chan struct{}, n)
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		counter <- struct{}{}
-		defer func() { <-counter }()
-
-		h.ServeHTTP(w, r)
-	})
-}
-
-func LimiterHandler(h http.Handler, n int) http.Handler {
-	counter := make(chan struct{}, n)
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		counter <- struct{}{}
-		defer func() { <-counter }()
-
-		h.ServeHTTP(w, r)
-	})
 }

--- a/api/limiter_test.go
+++ b/api/limiter_test.go
@@ -5,149 +5,164 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
-	"time"
 
+	"github.com/justinas/alice"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLimiterConcurrency(t *testing.T) {
-	maxConcurrency := MaxConcurrency(t, 0, 0) // no requests and no limits set
-	assert.Equal(t, 0, maxConcurrency)        // no concurrent requests
+func TestLimiterWithHeavyHandler(t *testing.T) {
+	result := ConcurrencyTest(t, HeavyHandler, 0, 0) // no requests and no limits set
+	assert.Equal(t, 0, result.maxConcurrency)        // no concurrent requests
+	assert.Equal(t, 0, result.accepted)
+	assert.Equal(t, 0, result.denied)
 
-	maxConcurrency = MaxConcurrency(t, 0, 10) // no requests and limit of 10 set
-	assert.Equal(t, 0, maxConcurrency)        // no concurrent requests
+	result = ConcurrencyTest(t, HeavyHandler, 0, 10) // no requests and limit of 10 set
+	assert.Equal(t, 0, result.maxConcurrency)        // no concurrent requests
+	assert.Equal(t, 0, result.accepted)
+	assert.Equal(t, 0, result.denied)
 
-	maxConcurrency = MaxConcurrency(t, 100, 0) // 100 requests and no limits set
-	assert.Equal(t, 100, maxConcurrency)       // 100 concurrent requests observed
+	result = ConcurrencyTest(t, HeavyHandler, 100, 0) // 100 requests and no limits set
+	assert.Equal(t, 100, result.maxConcurrency)       // 100 concurrent requests observed
+	assert.Equal(t, 100, result.accepted)
+	assert.Equal(t, 0, result.denied)
 
-	maxConcurrency = MaxConcurrency(t, 100, 1) // 100 requests and limit of 1 set
-	assert.Equal(t, 1, maxConcurrency)         // 1 concurrent request observed
+	result = ConcurrencyTest(t, HeavyHandler, 100, 1) // 100 requests and limit of 1 set
+	assert.Equal(t, 1, result.maxConcurrency)         // 1 concurrent request observed
+	assert.Equal(t, 1, result.accepted)
+	assert.Equal(t, 99, result.denied)
 
-	maxConcurrency = MaxConcurrency(t, 100, 10) // 100 requests and limit of 10 set
-	assert.Equal(t, 10, maxConcurrency)         // 10 concurrent requests observed
+	result = ConcurrencyTest(t, HeavyHandler, 100, 10) // 100 requests and limit of 10 set
+	assert.Equal(t, 10, result.maxConcurrency)         // 10 concurrent requests observed
+	assert.Equal(t, 10, result.accepted)
+	assert.Equal(t, 90, result.denied)
 
-	maxConcurrency = MaxConcurrency(t, 100, 100) // 100 requests and limit of 100 set
-	assert.Equal(t, 100, maxConcurrency)         // 100 concurrent requests observed
+	result = ConcurrencyTest(t, HeavyHandler, 100, 100) // 100 requests and limit of 100 set
+	assert.Equal(t, 100, result.maxConcurrency)         // 100 concurrent requests observed
+	assert.Equal(t, 100, result.accepted)
+	assert.Equal(t, 0, result.denied)
 
-	maxConcurrency = MaxConcurrency(t, 100, 1000) // 100 requests and limit of 1000 set
-	assert.Equal(t, 100, maxConcurrency)          // 100 concurrent requests observed
+	result = ConcurrencyTest(t, HeavyHandler, 100, 1000) // 100 requests and limit of 1000 set
+	assert.Equal(t, 100, result.maxConcurrency)          // 100 concurrent requests observed
+	assert.Equal(t, 100, result.accepted)
+	assert.Equal(t, 0, result.denied)
 }
 
-func TestStatusCodes(t *testing.T) {
-	accepted, denied := StatusCodes(t, 0, 0) // no requests and no limits set
-	assert.Equal(t, 0, accepted)
-	assert.Equal(t, 0, denied)
-
-	accepted, denied = StatusCodes(t, 0, 10) // no requests and limit of 10 set
-	assert.Equal(t, 0, accepted)
-	assert.Equal(t, 0, denied)
-
-	accepted, denied = StatusCodes(t, 100, 0) // 100 requests and no limits set
-	assert.Equal(t, 100, accepted)
-	assert.Equal(t, 0, denied)
-
-	accepted, denied = StatusCodes(t, 100, 1) // 100 requests and limit of 1 set
-	assert.Equal(t, 1, accepted)
-	assert.Equal(t, 99, denied)
-
-	accepted, denied = StatusCodes(t, 100, 10) // 100 requests and limit of 10 set
-	assert.Equal(t, 10, accepted)
-	assert.Equal(t, 90, denied)
-
-	accepted, denied = StatusCodes(t, 100, 100) // 100 requests and limit of 100 set
-	assert.Equal(t, 100, accepted)
-	assert.Equal(t, 0, denied)
-
-	accepted, denied = StatusCodes(t, 100, 1000) // 100 requests and limit of 1000 set
-	assert.Equal(t, 100, accepted)
-	assert.Equal(t, 0, denied)
+func TestLimiterWithLightHandler(t *testing.T) {
+	result := ConcurrencyTest(t, LightHandler, 1000, 10) // 1000 requests and limit of 10 set
+	assert.Equal(t, 10, result.maxConcurrency)           // no more than 10 concurrent requests at all times
+	assert.GreaterOrEqual(t, result.accepted, 10)        // but more than 10 were accepted overall
+	assert.Equal(t, 1000, result.accepted+result.denied) // no other responses than accepted or denied
 
 }
 
-func MaxConcurrency(t *testing.T, requestNumber int, limit int) int {
+type ConcurrencyTestResult struct {
+	maxConcurrency int
+	accepted       int
+	denied         int
+}
+
+type HandlerConstructor func(requestNumber int, limit int, counter chan<- int) http.Handler
+
+// HeavyHandler simulates a handler that performs task that is long enough for the server
+// to exhaust the maximum allowed number of concurrent handlers.
+// It does that by waiting in each handler until all of the other handlers have started
+// to execute. The number of handlers it waits for is decided by the requestNumber parameter.
+func HeavyHandler(requestNumber int, limit int, counter chan<- int) http.Handler {
+	var preLimiterWg sync.WaitGroup
+	preLimiterWg.Add(requestNumber)
+	preLimiter := func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			preLimiterWg.Done()
+			h.ServeHTTP(w, r)
+		})
+	}
+
+	var handlerWg sync.WaitGroup
+	limiter := Limiter(limit)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter <- 1
+		handlerWg.Add(1)
+		preLimiterWg.Wait()
+		handlerWg.Done()
+		handlerWg.Wait()
+		w.WriteHeader(200)
+		counter <- -1
+	})
+
+	return alice.New(preLimiter, limiter).Then(handler)
+}
+
+// LightHandler simply returns 200 OK status and finishes.
+// This is useful to test that the limiter allows next handlers as soon
+// as the previous have finished running.
+func LightHandler(requestNumber int, limit int, counter chan<- int) http.Handler {
+	limiter := Limiter(limit)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter <- 1
+		w.WriteHeader(200)
+		counter <- -1
+	})
+	return alice.New(limiter).Then(handler)
+}
+
+// ConcurrencyTest is a test helper that makes a given number of requests to a handler
+// created by HandlerConstructor that is concurrency limited to a given limit.
+// While running, it observes the current actual handler concurrency and returns
+// its maximum encountered value, as well as the number of 200 OK (allowed)
+// and 429 Too Many Requests (denied) responses received.
+func ConcurrencyTest(t *testing.T, hc HandlerConstructor, requestNumber int, limit int) ConcurrencyTestResult {
 
 	counter := make(chan int)
+	codes := make(chan int)
 
-	limiter := Limiter(limit)
-	handler := limiter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		counter <- 1
-		time.Sleep(10 * time.Millisecond)
-		w.WriteHeader(200)
-	}))
+	handler := hc(requestNumber, limit, counter)
 
-	var wg sync.WaitGroup
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	var requestsWg sync.WaitGroup
 	for i := 0; i < requestNumber; i++ {
-		wg.Add(1)
+		requestsWg.Add(1)
 		go func() {
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, nil)
-			counter <- -1
-
-			//assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
-			wg.Done()
+			res, err := http.Get(ts.URL)
+			assert.NoError(t, err)
+			codes <- res.StatusCode
+			requestsWg.Done()
 		}()
 	}
 
-	wait := make(chan struct{})
-	var concurrencyMax int
+	var resultsWg sync.WaitGroup
+	var result ConcurrencyTestResult
+
+	resultsWg.Add(2)
 	go func() {
 		var concurrencyNow int
 		for number := range counter {
 			concurrencyNow += number
-			if concurrencyNow > concurrencyMax {
-				concurrencyMax = concurrencyNow
+			if concurrencyNow > result.maxConcurrency {
+				result.maxConcurrency = concurrencyNow
 			}
 		}
-		close(wait)
+		resultsWg.Done()
 	}()
-
-	wg.Wait()
-	close(counter)
-	<-wait
-	return concurrencyMax
-}
-
-func StatusCodes(t *testing.T, requestNumber int, limit int) (int, int) {
-
-	codes := make(chan int)
-
-	limiter := Limiter(limit)
-	handler := limiter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		time.Sleep(10 * time.Millisecond)
-		w.WriteHeader(200)
-	}))
-
-	var wg sync.WaitGroup
-	for i := 0; i < requestNumber; i++ {
-		wg.Add(1)
-		go func() {
-			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, nil)
-			codes <- rec.Result().StatusCode
-
-			wg.Done()
-		}()
-	}
-
-	wait := make(chan struct{})
-	var accepted, denied int
 	go func() {
-
 		for number := range codes {
 			switch number {
 			case http.StatusOK:
-				accepted++
+				result.accepted++
 			case http.StatusTooManyRequests:
-				denied++
+				result.denied++
 			default:
 				assert.Failf(t, "bad response", "unexpected status code: %v", number)
 			}
 		}
-		close(wait)
+		resultsWg.Done()
 	}()
 
-	wg.Wait()
+	requestsWg.Wait()
+	close(counter)
 	close(codes)
-	<-wait
-	return accepted, denied
+	resultsWg.Wait()
+
+	return result
 }

--- a/api/limiter_test.go
+++ b/api/limiter_test.go
@@ -4,45 +4,150 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLimiter(t *testing.T) {
+func TestLimiterConcurrency(t *testing.T) {
+	maxConcurrency := MaxConcurrency(t, 0, 0) // no requests and no limits set
+	assert.Equal(t, 0, maxConcurrency)        // no concurrent requests
 
-	limit := 1
+	maxConcurrency = MaxConcurrency(t, 0, 10) // no requests and limit of 10 set
+	assert.Equal(t, 0, maxConcurrency)        // no concurrent requests
+
+	maxConcurrency = MaxConcurrency(t, 100, 0) // 100 requests and no limits set
+	assert.Equal(t, 100, maxConcurrency)       // 100 concurrent requests observed
+
+	maxConcurrency = MaxConcurrency(t, 100, 1) // 100 requests and limit of 1 set
+	assert.Equal(t, 1, maxConcurrency)         // 1 concurrent request observed
+
+	maxConcurrency = MaxConcurrency(t, 100, 10) // 100 requests and limit of 10 set
+	assert.Equal(t, 10, maxConcurrency)         // 10 concurrent requests observed
+
+	maxConcurrency = MaxConcurrency(t, 100, 100) // 100 requests and limit of 100 set
+	assert.Equal(t, 100, maxConcurrency)         // 100 concurrent requests observed
+
+	maxConcurrency = MaxConcurrency(t, 100, 1000) // 100 requests and limit of 1000 set
+	assert.Equal(t, 100, maxConcurrency)          // 100 concurrent requests observed
+}
+
+func TestStatusCodes(t *testing.T) {
+	accepted, denied := StatusCodes(t, 0, 0) // no requests and no limits set
+	assert.Equal(t, 0, accepted)
+	assert.Equal(t, 0, denied)
+
+	accepted, denied = StatusCodes(t, 0, 10) // no requests and limit of 10 set
+	assert.Equal(t, 0, accepted)
+	assert.Equal(t, 0, denied)
+
+	accepted, denied = StatusCodes(t, 100, 0) // 100 requests and no limits set
+	assert.Equal(t, 100, accepted)
+	assert.Equal(t, 0, denied)
+
+	accepted, denied = StatusCodes(t, 100, 1) // 100 requests and limit of 1 set
+	assert.Equal(t, 1, accepted)
+	assert.Equal(t, 99, denied)
+
+	accepted, denied = StatusCodes(t, 100, 10) // 100 requests and limit of 10 set
+	assert.Equal(t, 10, accepted)
+	assert.Equal(t, 90, denied)
+
+	accepted, denied = StatusCodes(t, 100, 100) // 100 requests and limit of 100 set
+	assert.Equal(t, 100, accepted)
+	assert.Equal(t, 0, denied)
+
+	accepted, denied = StatusCodes(t, 100, 1000) // 100 requests and limit of 1000 set
+	assert.Equal(t, 100, accepted)
+	assert.Equal(t, 0, denied)
+
+}
+
+func MaxConcurrency(t *testing.T, requestNumber int, limit int) int {
+
+	counter := make(chan int)
+
 	limiter := Limiter(limit)
-
-	var counter int64
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		concurrentHandlers := atomic.AddInt64(&counter, 1)
-		assert.LessOrEqual(t, concurrentHandlers, int64(limit))
-		time.Sleep(100 * time.Millisecond)
+	handler := limiter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		counter <- 1
+		time.Sleep(10 * time.Millisecond)
 		w.WriteHeader(200)
 	}))
-	handler = limiter(handler)
-
-	req, err := http.NewRequest("GET", "", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
+	for i := 0; i < requestNumber; i++ {
 		wg.Add(1)
 		go func() {
 			rec := httptest.NewRecorder()
-			handler.ServeHTTP(rec, req)
-			atomic.AddInt64(&counter, -1)
+			handler.ServeHTTP(rec, nil)
+			counter <- -1
 
-			assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+			//assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
 			wg.Done()
 		}()
 	}
 
+	wait := make(chan struct{})
+	var concurrencyMax int
+	go func() {
+		var concurrencyNow int
+		for number := range counter {
+			concurrencyNow += number
+			if concurrencyNow > concurrencyMax {
+				concurrencyMax = concurrencyNow
+			}
+		}
+		close(wait)
+	}()
+
 	wg.Wait()
+	close(counter)
+	<-wait
+	return concurrencyMax
+}
+
+func StatusCodes(t *testing.T, requestNumber int, limit int) (int, int) {
+
+	codes := make(chan int)
+
+	limiter := Limiter(limit)
+	handler := limiter(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(200)
+	}))
+
+	var wg sync.WaitGroup
+	for i := 0; i < requestNumber; i++ {
+		wg.Add(1)
+		go func() {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, nil)
+			codes <- rec.Result().StatusCode
+
+			wg.Done()
+		}()
+	}
+
+	wait := make(chan struct{})
+	var accepted, denied int
+	go func() {
+
+		for number := range codes {
+			switch number {
+			case http.StatusOK:
+				accepted++
+			case http.StatusTooManyRequests:
+				denied++
+			default:
+				assert.Failf(t, "bad response", "unexpected status code: %v", number)
+			}
+		}
+		close(wait)
+	}()
+
+	wg.Wait()
+	close(codes)
+	<-wait
+	return accepted, denied
 }

--- a/api/limiter_test.go
+++ b/api/limiter_test.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimiter(t *testing.T) {
+
+	limit := 1
+	limiter := Limiter(limit)
+
+	var counter int64
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		concurrentHandlers := atomic.AddInt64(&counter, 1)
+		assert.LessOrEqual(t, concurrentHandlers, int64(limit))
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(200)
+	}))
+	handler = limiter(handler)
+
+	req, err := http.NewRequest("GET", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			atomic.AddInt64(&counter, -1)
+
+			assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,9 +3,10 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/ONSdigital/log.go/v2/log"
 	"net/url"
 	"time"
+
+	"github.com/ONSdigital/log.go/v2/log"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -36,6 +37,7 @@ type Config struct {
 	IsPublishing               bool          `envconfig:"IS_PUBLISHING"`
 	EncryptionDisabled         bool          `envconfig:"ENCRYPTION_DISABLED"` // TODO remove encryption always required
 	PublicBucketURL            ConfigUrl     `envconfig:"PUBLIC_BUCKET_URL"`
+	MaxConcurrentHandlers      int           `envconfig:"MAX_CONCURRENT_HANDLERS"`
 }
 
 var cfg *Config
@@ -86,6 +88,7 @@ func Get() (*Config, error) {
 		IsPublishing:               true,
 		EncryptionDisabled:         false,
 		PublicBucketURL:            ConfigUrl{},
+		MaxConcurrentHandlers:      0, // unlimited
 	}
 
 	if err := envconfig.Process("", cfg); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,11 +1,12 @@
 package config
 
 import (
-	"github.com/kelseyhightower/envconfig"
 	"net/url"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/kelseyhightower/envconfig"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -39,6 +40,7 @@ func getConfigEnv() map[string]string {
 		"MONGODB_PASSWORD":             os.Getenv("MONGODB_PASSWORD"),
 		"MONGODB_IS_SSL":               os.Getenv("MONGODB_IS_SSL"),
 		"PUBLIC_BUCKET_URL":            os.Getenv("PUBLIC_BUCKET_URL"),
+		"MAX_CONCURRENT_HANDLERS":      os.Getenv("MAX_CONCURRENT_HANDLERS"),
 	}
 }
 
@@ -59,7 +61,6 @@ func TestSpec(t *testing.T) {
 		}
 
 		os.Setenv("PUBLIC_BUCKET_URL", "http://test")
-
 
 		config, err := Get()
 
@@ -89,6 +90,7 @@ func TestSpec(t *testing.T) {
 				So(config.MinioSecretKey, ShouldEqual, "")
 				So(config.IsPublishing, ShouldBeTrue)
 				So(config.EncryptionDisabled, ShouldBeFalse)
+				So(config.MaxConcurrentHandlers, ShouldEqual, 0)
 
 				expectedUrl, _ := url.Parse("http://test")
 				So(config.PublicBucketURL, ShouldResemble, ConfigUrl{*expectedUrl})

--- a/service/service.go
+++ b/service/service.go
@@ -168,6 +168,7 @@ func New(ctx context.Context, buildTime, gitCommit, version string, cfg *config.
 	// Create new middleware chain with whitelisted handler for /health endpoint
 	//
 	middlewareChain := alice.New(middleware.Whitelist(middleware.HealthcheckFilter(hc.Handler)))
+	middlewareChain = middlewareChain.Append(api.Limiter(cfg.MaxConcurrentHandlers))
 
 	// For non-whitelisted endpoints, do identityHandler or corsHandler
 	//


### PR DESCRIPTION
### What

Added configurable limiter middleware that that makes sure that no more than n handlers
are being executed in parallel. This is in order to make the service memory usage more predictable.

### How to review

Eyeball

### Who can review

Anyone
