### PR TITLE
Readd nomad vault policies

### DIFF
--- a/dp-download-service.nomad
+++ b/dp-download-service.nomad
@@ -70,6 +70,13 @@ job "dp-download-service" {
         source      = "${NOMAD_TASK_DIR}/vars-template"
         destination = "${NOMAD_TASK_DIR}/vars"
       }
+
+      vault {
+        policies = ["dp-download-service-web"]
+
+        change_mode   = "signal"
+        change_signal = "SIGUSR1"
+      }
     }
   }
 
@@ -131,6 +138,13 @@ job "dp-download-service" {
       template {
         source      = "${NOMAD_TASK_DIR}/vars-template"
         destination = "${NOMAD_TASK_DIR}/vars"
+      }
+
+      vault {
+        policies = ["dp-download-service-publishing"]
+
+        change_mode   = "signal"
+        change_signal = "SIGUSR1"
       }
     }
   }


### PR DESCRIPTION
### What

Readded removed vault policies, these were taken out as part of the double encryption removal, but should not have been as it allows the dp-config secrets into the service

### How to review

Visual check

### Who can review

Anyone
