### PR TITLE
ignore audit failures with no fix available

### DIFF
--- a/.dis-vulncheck.yml
+++ b/.dis-vulncheck.yml
@@ -1,0 +1,7 @@
+ignore:
+  - id: GO-2026-4883
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.
+  - id: GO-2026-4887
+    module: github.com/docker/docker
+    reason: No fix available; transitive dependency via dp-component-test -> testcontainers-go; only used for testing, not used by service runtime.


### PR DESCRIPTION
### What

- Add vulncheck ignore file for audit failures with no fix
- https://pkg.go.dev/vuln/GO-2026-4883
- Although this is fixed within github.com/docker/docker, it is imported by testcontainers-go which does not have a release with the fix available. (Which is imported via dp-component-test)

### How to review

- Check changes are ok

### Who can review

- Anyone
