### PR TITLE
Standardise component test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test:
 lint:
 	golangci-lint run ./...
 
-docker-test-component:
+test-component:
 	docker-compose -f docker-compose.yml down
 	docker-compose -f docker-compose.yml up --abort-on-container-exit
 	docker-compose -f docker-compose.yml down

--- a/ci/scripts/component.sh
+++ b/ci/scripts/component.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eux
 
 pushd dp-download-service
-  make docker-test-component
+  make test-component
 popd


### PR DESCRIPTION
### What

There are a number of repos where the make command to run the component test is different to the common command. We want to change it so it is standard across all the repos.

### How to review

`make test-component` and check it runs the component test
Check the change has also worked in CI

### Who can review

Anyone