### PR TITLE
Feature/use new custom timeouts in http server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,8 +26,10 @@ type Config struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"  json:"-"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	RequestTimeout             time.Duration `envconfig:"REQUEST_TIMEOUT"`
+	ReadTimeout                time.Duration `envconfig:"READ_TIMEOUT"`
 	WriteTimeout               time.Duration `envconfig:"WRITE_TIMEOUT"`
+	IdleTimeout                time.Duration `envconfig:"IDLE_TIMEOUT"`
+	ReadHeaderTimeout          time.Duration `envconfig:"READ_HEADER_TIMEOUT"`
 	TimeoutMessage             string        `envconfig:"TIMEOUT_MESSAGE"`
 	ServiceAuthToken           string        `envconfig:"SERVICE_AUTH_TOKEN"         json:"-"`
 	SecretKey                  string        `envconfig:"SECRET_KEY"                 json:"-"`
@@ -77,8 +79,10 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		RequestTimeout:             5 * time.Second,
+		ReadTimeout:                5 * time.Second,
 		WriteTimeout:               10 * time.Second,
+		IdleTimeout:                0,
+		ReadHeaderTimeout:          0,
 		TimeoutMessage:             "The request timed out",
 		ServiceAuthToken:           "c60198e9-1864-4b68-ad0b-1e858e5b46a4",
 		LocalObjectStore:           "",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,6 +37,10 @@ func getConfigEnv() map[string]string {
 		"MONGODB_IS_SSL":               os.Getenv("MONGODB_IS_SSL"),
 		"PUBLIC_BUCKET_URL":            os.Getenv("PUBLIC_BUCKET_URL"),
 		"MAX_CONCURRENT_HANDLERS":      os.Getenv("MAX_CONCURRENT_HANDLERS"),
+		"READ_TIMEOUT":                 os.Getenv("READ_TIMEOUT"),
+		"WRITE_TIMEOUT":                os.Getenv("WRITE_TIMEOUT"),
+		"IDLE_TIMEOUT":                 os.Getenv("IDLE_TIMEOUT"),
+		"READ_HEADER_TIMEOUT":          os.Getenv("READ_HEADER_TIMEOUT"),
 	}
 }
 
@@ -83,6 +87,10 @@ func TestSpec(t *testing.T) {
 				So(config.MinioSecretKey, ShouldEqual, "")
 				So(config.IsPublishing, ShouldBeTrue)
 				So(config.MaxConcurrentHandlers, ShouldEqual, 0)
+				So(config.ReadTimeout, ShouldEqual, 5*time.Second)
+				So(config.WriteTimeout, ShouldEqual, 10*time.Second)
+				So(config.IdleTimeout, ShouldEqual, 0)
+				So(config.ReadHeaderTimeout, ShouldEqual, 0)
 
 				expectedUrl, _ := url.Parse("http://test")
 				So(config.PublicBucketURL, ShouldResemble, URL{*expectedUrl})

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-component-test v1.4.4-alpha
 	github.com/ONSdigital/dp-files-api v1.22.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
-	github.com/ONSdigital/dp-net/v3 v3.12.0
+	github.com/ONSdigital/dp-net/v3 v3.13.0
 	github.com/ONSdigital/dp-permissions-api v1.10.1
 	github.com/ONSdigital/dp-s3/v3 v3.3.0
 	github.com/ONSdigital/log.go/v2 v2.5.2

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/ONSdigital/dp-mongodb/v3 v3.13.0 h1:nTb47hKUj4wI3+1Q9KxqYRr6iDfh6/xlu
 github.com/ONSdigital/dp-mongodb/v3 v3.13.0/go.mod h1:/68EwFrtOgChAMMfaUTm3kTHe2zvB3MZtizrvz1vVxw=
 github.com/ONSdigital/dp-net/v2 v2.22.0 h1:LY9C5x1+sfK9QyjNpB2G3TPvAtSuOFR9FRcXsR9twqs=
 github.com/ONSdigital/dp-net/v2 v2.22.0/go.mod h1:F6yL3jjuVwBLVMFIKgHF3zhMRbmZysAxBiu+aIAi3Z0=
-github.com/ONSdigital/dp-net/v3 v3.12.0 h1:RmMNjDi+WaUlNbfGZy3r1ob5B2+QYYgYtKPDM6tBWaA=
-github.com/ONSdigital/dp-net/v3 v3.12.0/go.mod h1:6CWNGULkexaBdw5/H4i080ufb5r4tuu/pMqWdUK9O78=
+github.com/ONSdigital/dp-net/v3 v3.13.0 h1:1fwK9G+f32k+NdJnzRT7EG0C9R7qcrHQs4Lah0hCczk=
+github.com/ONSdigital/dp-net/v3 v3.13.0/go.mod h1:6CWNGULkexaBdw5/H4i080ufb5r4tuu/pMqWdUK9O78=
 github.com/ONSdigital/dp-permissions-api v1.10.1 h1:dOyPtS94CpBgS0Y1oZJy84UcKZOHkmDK+Zdg5OClEXs=
 github.com/ONSdigital/dp-permissions-api v1.10.1/go.mod h1:436ej+daY+8+hNCReDvCIsI0iNRWKU/UZsxC09CRMNA=
 github.com/ONSdigital/dp-s3/v3 v3.3.0 h1:l5QrJ4lFHMfhHmk0Cox+0xSNQ6RhkCHJ6ikqq5XNLi4=

--- a/service/external/external.go
+++ b/service/external/external.go
@@ -96,8 +96,8 @@ func (*External) HTTPServer(cfg *config.Config, r http.Handler) service.HTTPServ
 	timeoutConfig := dphttp.TimeoutConfig{
 		ReadTimeout:       cfg.ReadTimeout,
 		WriteTimeout:      cfg.WriteTimeout,
-		IdleTimeout:       0,
-		ReadHeaderTimeout: 0,
+		IdleTimeout:       cfg.IdleTimeout,
+		ReadHeaderTimeout: cfg.ReadHeaderTimeout,
 	}
 
 	s := dphttp.NewServerWithCustomTimeouts(cfg.BindAddr, r, timeoutConfig)

--- a/service/external/external.go
+++ b/service/external/external.go
@@ -93,7 +93,15 @@ func (*External) HealthCheck(cfg *config.Config, buildTime, gitCommit, version s
 }
 
 func (*External) HTTPServer(cfg *config.Config, r http.Handler) service.HTTPServer {
-	s := dphttp.NewServerWithTimeout(cfg.BindAddr, r, cfg.RequestTimeout, cfg.WriteTimeout, cfg.TimeoutMessage)
+	timeoutConfig := dphttp.TimeoutConfig{
+		ReadTimeout:       cfg.ReadTimeout,
+		WriteTimeout:      cfg.WriteTimeout,
+		IdleTimeout:       0,
+		ReadHeaderTimeout: 0,
+	}
+
+	s := dphttp.NewServerWithCustomTimeouts(cfg.BindAddr, r, timeoutConfig)
+
 	s.HandleOSSignals = false
 
 	return s


### PR DESCRIPTION
### What

Use new http server instantiation function from dp-net to address performance implications.
Adjusted config values to more accurately reflect the values the custom timeout settings require.

### How to review

Ensure the tests pass and the changes make sense.
For a more detailed review, run the dataset catalogue stack and upload some files using the upload-service.  Ensure these files can still be downloaded using this service.

### Who can review

Anyone.
