### PR TITLE
Allow downloads where the series/edition IDs have changed

### DIFF
--- a/api/download.go
+++ b/api/download.go
@@ -110,30 +110,23 @@ func CreateDownloadHandlerNoAuth(fetchMetadata files.MetadataFetcher, downloadFi
 
 func checkPermissionsAttributes(ctx context.Context, logData log.Data, permission string, metadata *filesAPIModels.StoredRegisteredMetaData, permissionsChecker auth.PermissionsChecker, entityData *permissionsAPISDK.EntityData) bool {
 	if metadata == nil || metadata.ContentItem == nil {
-		return true
+		return checkUserPermission(ctx, logData, permission, nil, permissionsChecker, entityData)
 	}
 
-	datasetIds := append(metadata.ContentItem.PreviousSeriesId, metadata.ContentItem.DatasetID)
-	editionIds := append(metadata.ContentItem.PreviousEditionId, metadata.ContentItem.Edition)
+	allSeriesIDs := append([]string{metadata.ContentItem.DatasetID}, metadata.ContentItem.PreviousSeriesId...)
+	allEditionIDs := append([]string{metadata.ContentItem.Edition}, metadata.ContentItem.PreviousEditionId...)
 
-	if len(datasetIds) == 0 || len(editionIds) == 0 {
-		return true
-	}
-
-	idCombinations := make([][2]string, 0, len(datasetIds)*len(editionIds))
-	for _, datasetId := range datasetIds {
-		for _, editionId := range editionIds {
-			idCombinations = append(idCombinations, [2]string{datasetId, editionId})
-		}
-	}
-	for _, combination := range idCombinations {
-		permissionAttrs := map[string]string{"dataset_edition": combination[0] + "/" + combination[1]}
-		if checkUserPermission(ctx, logData, permission, permissionAttrs, permissionsChecker, entityData) {
-			return true
+	for _, datasetID := range allSeriesIDs {
+		for _, edition := range allEditionIDs {
+			if datasetID != "" && edition != "" {
+				if checkUserPermission(ctx, logData, permission, map[string]string{"dataset_edition": datasetID + "/" + edition}, permissionsChecker, entityData) {
+					return true
+				}
+			}
 		}
 	}
 
-	return false
+	return checkUserPermission(ctx, logData, permission, nil, permissionsChecker, entityData)
 }
 
 func recordFileEvent(ctx context.Context, entityData permissionsAPISDK.EntityData, accessToken, requestedFilePath string, metadata *filesAPIModels.StoredRegisteredMetaData, w http.ResponseWriter, createFileEvent files.FileEventCreator) error {

--- a/api/download.go
+++ b/api/download.go
@@ -57,11 +57,11 @@ func CreateDownloadHandlerWithAuth(fetchMetadata files.MetadataFetcher, download
 				return
 			}
 
-			permissionAttrs := setPermissionsAttributes(metadata)
-
 			logData["entity_data"] = entityData
 
-			if checkUserPermission(ctx, logData, "static-files:read", permissionAttrs, permissionsChecker, entityData) {
+			authorised := checkPermissionsAttributes(ctx, logData, "static-files:read", metadata, permissionsChecker, entityData)
+
+			if authorised {
 				// Passing identifier as both user and email parameters as the identity client only provides a single identifier
 				err = recordFileEvent(ctx, *entityData, accessToken, requestedFilePath, metadata, w, createFileEvent)
 				if err != nil {
@@ -108,17 +108,32 @@ func CreateDownloadHandlerNoAuth(fetchMetadata files.MetadataFetcher, downloadFi
 	}
 }
 
-func setPermissionsAttributes(metadata *filesAPIModels.StoredRegisteredMetaData) map[string]string {
-	var permissionAttrs map[string]string
-	if metadata.ContentItem != nil {
-		if metadata.ContentItem.DatasetID != "" && metadata.ContentItem.Edition != "" {
-			permissionAttrs = map[string]string{
-				"dataset_edition": metadata.ContentItem.DatasetID + "/" + metadata.ContentItem.Edition,
-			}
+func checkPermissionsAttributes(ctx context.Context, logData log.Data, permission string, metadata *filesAPIModels.StoredRegisteredMetaData, permissionsChecker auth.PermissionsChecker, entityData *permissionsAPISDK.EntityData) bool {
+	if metadata == nil || metadata.ContentItem == nil {
+		return true
+	}
+
+	datasetIds := append(metadata.ContentItem.PreviousSeriesId, metadata.ContentItem.DatasetID)
+	editionIds := append(metadata.ContentItem.PreviousEditionId, metadata.ContentItem.Edition)
+
+	if len(datasetIds) == 0 || len(editionIds) == 0 {
+		return true
+	}
+
+	idCombinations := make([][2]string, 0, len(datasetIds)*len(editionIds))
+	for _, datasetId := range datasetIds {
+		for _, editionId := range editionIds {
+			idCombinations = append(idCombinations, [2]string{datasetId, editionId})
+		}
+	}
+	for _, combination := range idCombinations {
+		permissionAttrs := map[string]string{"dataset_edition": combination[0] + "/" + combination[1]}
+		if checkUserPermission(ctx, logData, permission, permissionAttrs, permissionsChecker, entityData) {
+			return true
 		}
 	}
 
-	return permissionAttrs
+	return false
 }
 
 func recordFileEvent(ctx context.Context, entityData permissionsAPISDK.EntityData, accessToken, requestedFilePath string, metadata *filesAPIModels.StoredRegisteredMetaData, w http.ResponseWriter, createFileEvent files.FileEventCreator) error {

--- a/api/download_test.go
+++ b/api/download_test.go
@@ -19,6 +19,7 @@ import (
 	filesAPISDK "github.com/ONSdigital/dp-files-api/sdk"
 	dprequest "github.com/ONSdigital/dp-net/v3/request"
 	permissionsAPISDK "github.com/ONSdigital/dp-permissions-api/sdk"
+	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -472,4 +473,183 @@ func TestRedirectLocation(t *testing.T) {
 		concatenatedUrl := RedirectLocation(&config.Config{PublicBucketURL: configUrl}, test.filepath)
 		assert.Equal(t, expectedUrl, concatenatedUrl, fmt.Sprintf("testing %s: expected %s, got %s", test.desc, expectedUrl, concatenatedUrl))
 	}
+}
+
+func TestCheckPermissionsAttributesPreviousSeriesAndEditionIDs(t *testing.T) {
+	t.Run("With only previous series ID", func(t *testing.T) {
+		permissionCheckCalls := 0
+		permissionsChecker := &authMock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permissionsAPISDK.EntityData, permission string, attributes map[string]string) (bool, error) {
+				permissionCheckCalls++
+				return false, nil
+			},
+		}
+
+		metadata := &filesAPIModels.StoredRegisteredMetaData{
+			ContentItem: &filesAPIModels.StoredContentItem{
+				PreviousSeriesId: []string{"series-1"},
+				DatasetID:        "dataset-1",
+				PreviousEditionId: []string{},
+				Edition:          "2024",
+			},
+		}
+
+		entityData := &permissionsAPISDK.EntityData{UserID: "user-1"}
+		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
+
+		assert.False(t, result)
+		assert.Equal(t, 2, permissionCheckCalls)
+	})
+
+	t.Run("With only previous edition ID", func(t *testing.T) {
+		permissionCheckCalls := 0
+		permissionsChecker := &authMock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permissionsAPISDK.EntityData, permission string, attributes map[string]string) (bool, error) {
+				permissionCheckCalls++
+				return false, nil
+			},
+		}
+
+		metadata := &filesAPIModels.StoredRegisteredMetaData{
+			ContentItem: &filesAPIModels.StoredContentItem{
+				PreviousSeriesId: []string{},
+				DatasetID:        "dataset-1",
+				PreviousEditionId: []string{"edition-1"},
+				Edition:          "2024",
+			},
+		}
+
+		entityData := &permissionsAPISDK.EntityData{UserID: "user-1"}
+		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
+
+		assert.False(t, result)
+		assert.Equal(t, 2, permissionCheckCalls)
+	})
+
+	t.Run("With both previous series and edition IDs", func(t *testing.T) {
+		permissionCheckCalls := 0
+		permissionsChecker := &authMock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permissionsAPISDK.EntityData, permission string, attributes map[string]string) (bool, error) {
+				permissionCheckCalls++
+				return false, nil
+			},
+		}
+
+		metadata := &filesAPIModels.StoredRegisteredMetaData{
+			ContentItem: &filesAPIModels.StoredContentItem{
+				PreviousSeriesId: []string{"series-1", "series-2"},
+				DatasetID:        "dataset-1",
+				PreviousEditionId: []string{"edition-1"},
+				Edition:          "2024",
+			},
+		}
+
+		entityData := &permissionsAPISDK.EntityData{UserID: "user-1"}
+		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
+
+		assert.False(t, result)
+		assert.Equal(t, 6, permissionCheckCalls)
+	})
+}
+
+func TestCheckPermissionsAttributesPreviousIDsGrantAccess(t *testing.T) {
+	t.Run("Access granted on first previous series ID", func(t *testing.T) {
+		permissionCheckCalls := 0
+		permissionsChecker := &authMock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permissionsAPISDK.EntityData, permission string, attributes map[string]string) (bool, error) {
+				permissionCheckCalls++
+				return permissionCheckCalls == 1, nil
+			},
+		}
+
+		metadata := &filesAPIModels.StoredRegisteredMetaData{
+			ContentItem: &filesAPIModels.StoredContentItem{
+				PreviousSeriesId: []string{"series-1"},
+				DatasetID:        "dataset-1",
+				PreviousEditionId: []string{},
+				Edition:          "2024",
+			},
+		}
+
+		entityData := &permissionsAPISDK.EntityData{UserID: "user-1"}
+		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
+
+		assert.True(t, result)
+		assert.Equal(t, 1, permissionCheckCalls)
+	})
+
+	t.Run("Access granted on second previous series ID", func(t *testing.T) {
+		permissionCheckCalls := 0
+		permissionsChecker := &authMock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permissionsAPISDK.EntityData, permission string, attributes map[string]string) (bool, error) {
+				permissionCheckCalls++
+				return permissionCheckCalls == 2, nil
+			},
+		}
+
+		metadata := &filesAPIModels.StoredRegisteredMetaData{
+			ContentItem: &filesAPIModels.StoredContentItem{
+				PreviousSeriesId: []string{"series-1", "series-2"},
+				DatasetID:        "dataset-1",
+				PreviousEditionId: []string{},
+				Edition:          "2024",
+			},
+		}
+
+		entityData := &permissionsAPISDK.EntityData{UserID: "user-1"}
+		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
+
+		assert.True(t, result)
+		assert.Equal(t, 2, permissionCheckCalls)
+	})
+
+	t.Run("Access granted on previous edition ID", func(t *testing.T) {
+		permissionCheckCalls := 0
+		permissionsChecker := &authMock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permissionsAPISDK.EntityData, permission string, attributes map[string]string) (bool, error) {
+				permissionCheckCalls++
+				return permissionCheckCalls == 2, nil
+			},
+		}
+
+		metadata := &filesAPIModels.StoredRegisteredMetaData{
+			ContentItem: &filesAPIModels.StoredContentItem{
+				PreviousSeriesId: []string{"series-1"},
+				DatasetID:        "dataset-1",
+				PreviousEditionId: []string{"edition-1"},
+				Edition:          "2024",
+			},
+		}
+
+		entityData := &permissionsAPISDK.EntityData{UserID: "user-1"}
+		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
+
+		assert.True(t, result)
+		assert.Equal(t, 2, permissionCheckCalls)
+	})
+
+	t.Run("Access granted on current dataset/edition with previous IDs present", func(t *testing.T) {
+		permissionCheckCalls := 0
+		permissionsChecker := &authMock.PermissionsCheckerMock{
+			HasPermissionFunc: func(ctx context.Context, entityData permissionsAPISDK.EntityData, permission string, attributes map[string]string) (bool, error) {
+				permissionCheckCalls++
+				return permissionCheckCalls == 4, nil
+			},
+		}
+
+		metadata := &filesAPIModels.StoredRegisteredMetaData{
+			ContentItem: &filesAPIModels.StoredContentItem{
+				PreviousSeriesId: []string{"series-1"},
+				DatasetID:        "dataset-1",
+				PreviousEditionId: []string{"edition-1"},
+				Edition:          "2024",
+			},
+		}
+
+		entityData := &permissionsAPISDK.EntityData{UserID: "user-1"}
+		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
+
+		assert.True(t, result)
+		assert.Equal(t, 4, permissionCheckCalls)
+	})
 }

--- a/api/download_test.go
+++ b/api/download_test.go
@@ -487,10 +487,10 @@ func TestCheckPermissionsAttributesPreviousSeriesAndEditionIDs(t *testing.T) {
 
 		metadata := &filesAPIModels.StoredRegisteredMetaData{
 			ContentItem: &filesAPIModels.StoredContentItem{
-				PreviousSeriesId: []string{"series-1"},
-				DatasetID:        "dataset-1",
+				PreviousSeriesId:  []string{"series-1"},
+				DatasetID:         "dataset-1",
 				PreviousEditionId: []string{},
-				Edition:          "2024",
+				Edition:           "2024",
 			},
 		}
 
@@ -498,7 +498,7 @@ func TestCheckPermissionsAttributesPreviousSeriesAndEditionIDs(t *testing.T) {
 		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
 
 		assert.False(t, result)
-		assert.Equal(t, 2, permissionCheckCalls)
+		assert.Equal(t, 3, permissionCheckCalls)
 	})
 
 	t.Run("With only previous edition ID", func(t *testing.T) {
@@ -512,10 +512,10 @@ func TestCheckPermissionsAttributesPreviousSeriesAndEditionIDs(t *testing.T) {
 
 		metadata := &filesAPIModels.StoredRegisteredMetaData{
 			ContentItem: &filesAPIModels.StoredContentItem{
-				PreviousSeriesId: []string{},
-				DatasetID:        "dataset-1",
+				PreviousSeriesId:  []string{},
+				DatasetID:         "dataset-1",
 				PreviousEditionId: []string{"edition-1"},
-				Edition:          "2024",
+				Edition:           "2024",
 			},
 		}
 
@@ -523,7 +523,7 @@ func TestCheckPermissionsAttributesPreviousSeriesAndEditionIDs(t *testing.T) {
 		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
 
 		assert.False(t, result)
-		assert.Equal(t, 2, permissionCheckCalls)
+		assert.Equal(t, 3, permissionCheckCalls)
 	})
 
 	t.Run("With both previous series and edition IDs", func(t *testing.T) {
@@ -537,10 +537,10 @@ func TestCheckPermissionsAttributesPreviousSeriesAndEditionIDs(t *testing.T) {
 
 		metadata := &filesAPIModels.StoredRegisteredMetaData{
 			ContentItem: &filesAPIModels.StoredContentItem{
-				PreviousSeriesId: []string{"series-1", "series-2"},
-				DatasetID:        "dataset-1",
+				PreviousSeriesId:  []string{"series-1", "series-2"},
+				DatasetID:         "dataset-1",
 				PreviousEditionId: []string{"edition-1"},
-				Edition:          "2024",
+				Edition:           "2024",
 			},
 		}
 
@@ -548,7 +548,7 @@ func TestCheckPermissionsAttributesPreviousSeriesAndEditionIDs(t *testing.T) {
 		result := checkPermissionsAttributes(context.Background(), log.Data{}, "static-files:read", metadata, permissionsChecker, entityData)
 
 		assert.False(t, result)
-		assert.Equal(t, 6, permissionCheckCalls)
+		assert.Equal(t, 7, permissionCheckCalls)
 	})
 }
 
@@ -564,10 +564,10 @@ func TestCheckPermissionsAttributesPreviousIDsGrantAccess(t *testing.T) {
 
 		metadata := &filesAPIModels.StoredRegisteredMetaData{
 			ContentItem: &filesAPIModels.StoredContentItem{
-				PreviousSeriesId: []string{"series-1"},
-				DatasetID:        "dataset-1",
+				PreviousSeriesId:  []string{"series-1"},
+				DatasetID:         "dataset-1",
 				PreviousEditionId: []string{},
-				Edition:          "2024",
+				Edition:           "2024",
 			},
 		}
 
@@ -589,10 +589,10 @@ func TestCheckPermissionsAttributesPreviousIDsGrantAccess(t *testing.T) {
 
 		metadata := &filesAPIModels.StoredRegisteredMetaData{
 			ContentItem: &filesAPIModels.StoredContentItem{
-				PreviousSeriesId: []string{"series-1", "series-2"},
-				DatasetID:        "dataset-1",
+				PreviousSeriesId:  []string{"series-1", "series-2"},
+				DatasetID:         "dataset-1",
 				PreviousEditionId: []string{},
-				Edition:          "2024",
+				Edition:           "2024",
 			},
 		}
 
@@ -614,10 +614,10 @@ func TestCheckPermissionsAttributesPreviousIDsGrantAccess(t *testing.T) {
 
 		metadata := &filesAPIModels.StoredRegisteredMetaData{
 			ContentItem: &filesAPIModels.StoredContentItem{
-				PreviousSeriesId: []string{"series-1"},
-				DatasetID:        "dataset-1",
+				PreviousSeriesId:  []string{"series-1"},
+				DatasetID:         "dataset-1",
 				PreviousEditionId: []string{"edition-1"},
-				Edition:          "2024",
+				Edition:           "2024",
 			},
 		}
 
@@ -639,10 +639,10 @@ func TestCheckPermissionsAttributesPreviousIDsGrantAccess(t *testing.T) {
 
 		metadata := &filesAPIModels.StoredRegisteredMetaData{
 			ContentItem: &filesAPIModels.StoredContentItem{
-				PreviousSeriesId: []string{"series-1"},
-				DatasetID:        "dataset-1",
+				PreviousSeriesId:  []string{"series-1"},
+				DatasetID:         "dataset-1",
 				PreviousEditionId: []string{"edition-1"},
-				Edition:          "2024",
+				Edition:           "2024",
 			},
 		}
 

--- a/features/download_files_publishing_mode.feature
+++ b/features/download_files_publishing_mode.feature
@@ -278,7 +278,112 @@ Feature: Download preview feature - publishing
         When I GET "/downloads-new/data/return401.csv"
         Then the HTTP status code should be "401"
         And the response header "Cache-Control" should be "no-cache"
-    
-    
-  
-  
+
+    Scenario: An authorised viewer user requests a file using previous series ID for permission checks
+      Given the file "data/unpublished-previous-series.csv" has the metadata:
+        """
+        {
+          "path": "data/unpublished-previous-series.csv",
+          "is_publishable": true,
+          "collection_id": "1234-asdfg-54321-qwerty",
+          "title": "The number of people",
+          "size_in_bytes": 29,
+          "type": "text/csv",
+          "licence": "OGL v3",
+          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+          "state": "UPLOADED",
+          "content_item": {
+            "dataset_id": "different-dataset",
+            "previous_series_id": ["cpih01"],
+            "edition": "feb-2026"
+          }
+        }
+        """
+      And I am a viewer user with permission
+      And the file "data/unpublished-previous-series.csv" is in S3 with content:
+        """
+        mark,1
+        russ,2
+        dan,3
+        saul,3.5
+        brian,4
+        jon,5
+        """
+      When I GET "/downloads/files/data/unpublished-previous-series.csv"
+      Then the HTTP status code should be "200"
+      And the response header "Cache-Control" should be "no-cache"
+      And the response header "Content-Disposition" should be "attachment; filename=unpublished-previous-series.csv"
+      And a file event with action "READ" and resource "data/unpublished-previous-series.csv" should be created by user "viewer1@ons.gov.uk"
+
+    Scenario: An authorised viewer user requests a file using previous edition ID for permission checks
+      Given the file "data/unpublished-previous-edition.csv" has the metadata:
+        """
+        {
+          "path": "data/unpublished-previous-edition.csv",
+          "is_publishable": true,
+          "collection_id": "1234-asdfg-54321-qwerty",
+          "title": "The number of people",
+          "size_in_bytes": 29,
+          "type": "text/csv",
+          "licence": "OGL v3",
+          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+          "state": "UPLOADED",
+          "content_item": {
+            "dataset_id": "cpih01",
+            "edition": "different-edition",
+            "previous_edition_id": ["feb-2026"]
+          }
+        }
+        """
+      And I am a viewer user with permission
+      And the file "data/unpublished-previous-edition.csv" is in S3 with content:
+        """
+        mark,1
+        russ,2
+        dan,3
+        saul,3.5
+        brian,4
+        jon,5
+        """
+      When I GET "/downloads/files/data/unpublished-previous-edition.csv"
+      Then the HTTP status code should be "200"
+      And the response header "Cache-Control" should be "no-cache"
+      And the response header "Content-Disposition" should be "attachment; filename=unpublished-previous-edition.csv"
+      And a file event with action "READ" and resource "data/unpublished-previous-edition.csv" should be created by user "viewer1@ons.gov.uk"
+
+    Scenario: An authorised viewer user requests a file using previous series and previous edition IDs for permission checks
+      Given the file "data/unpublished-previous-series-edition.csv" has the metadata:
+        """
+        {
+          "path": "data/unpublished-previous-series-edition.csv",
+          "is_publishable": true,
+          "collection_id": "1234-asdfg-54321-qwerty",
+          "title": "The number of people",
+          "size_in_bytes": 29,
+          "type": "text/csv",
+          "licence": "OGL v3",
+          "licence_url": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
+          "state": "UPLOADED",
+          "content_item": {
+            "dataset_id": "different-dataset",
+            "previous_series_id": ["cpih01"],
+            "edition": "different-edition",
+            "previous_edition_id": ["feb-2026"]
+          }
+        }
+        """
+      And I am a viewer user with permission
+      And the file "data/unpublished-previous-series-edition.csv" is in S3 with content:
+        """
+        mark,1
+        russ,2
+        dan,3
+        saul,3.5
+        brian,4
+        jon,5
+        """
+      When I GET "/downloads/files/data/unpublished-previous-series-edition.csv"
+      Then the HTTP status code should be "200"
+      And the response header "Cache-Control" should be "no-cache"
+      And the response header "Content-Disposition" should be "attachment; filename=unpublished-previous-series-edition.csv"
+      And a file event with action "READ" and resource "data/unpublished-previous-series-edition.csv" should be created by user "viewer1@ons.gov.uk"

--- a/features/steps/external.go
+++ b/features/steps/external.go
@@ -89,6 +89,12 @@ func (e *External) FilesClient(s string) downloads.FilesClient {
 				return nil, fmt.Errorf("file not registered")
 			case "data/return401.csv":
 				return nil, fmt.Errorf("API error: status code 401")
+			case "data/unpublished-previous-series.csv":
+				return &filesAPIModels.StoredRegisteredMetaData{State: "UPLOADED", Path: path, Type: "text/csv", SizeInBytes: 29, ContentItem: &filesAPIModels.StoredContentItem{DatasetID: "different-dataset", PreviousSeriesId: []string{"cpih01"}, Edition: "feb-2026"}}, nil
+			case "data/unpublished-previous-edition.csv":
+				return &filesAPIModels.StoredRegisteredMetaData{State: "UPLOADED", Path: path, Type: "text/csv", SizeInBytes: 29, ContentItem: &filesAPIModels.StoredContentItem{DatasetID: "cpih01", PreviousEditionId: []string{"feb-2026"}, Edition: "different-edition"}}, nil
+			case "data/unpublished-previous-series-edition.csv":
+				return &filesAPIModels.StoredRegisteredMetaData{State: "UPLOADED", Path: path, Type: "text/csv", SizeInBytes: 29, ContentItem: &filesAPIModels.StoredContentItem{DatasetID: "different-dataset", PreviousSeriesId: []string{"cpih01"}, PreviousEditionId: []string{"feb-2026"}, Edition: "different-edition"}}, nil
 			default:
 				return nil, fmt.Errorf("unknown mock path")
 			}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.282.0
 	github.com/ONSdigital/dp-authorisation/v2 v2.34.0
-	github.com/ONSdigital/dp-component-test v1.4.4-alpha
+	github.com/ONSdigital/dp-component-test v1.4.7
 	github.com/ONSdigital/dp-files-api v1.22.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.13.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.282.0
 	github.com/ONSdigital/dp-authorisation/v2 v2.34.0
 	github.com/ONSdigital/dp-component-test v1.4.7
-	github.com/ONSdigital/dp-files-api v1.22.0
+	github.com/ONSdigital/dp-files-api v1.28.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.13.0
 	github.com/ONSdigital/dp-permissions-api v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/ONSdigital/dp-authorisation/v2 v2.34.0 h1:Zc096gAh5S7PFG1LlbM/siZDvyz
 github.com/ONSdigital/dp-authorisation/v2 v2.34.0/go.mod h1:y3zXIX/x8baEKucG05v/PL86GtL7MAz9Eb3HcwZmuvQ=
 github.com/ONSdigital/dp-component-test v1.4.7 h1:rl09EiuinyEWNIUMbi0zHmTOcgMo96nx1g7VuXxS/Xo=
 github.com/ONSdigital/dp-component-test v1.4.7/go.mod h1:M4AHtkKgyud7xL3drcp+CtioENDLJyUdvHjQC5DuWmQ=
-github.com/ONSdigital/dp-files-api v1.22.0 h1:aKUKfWEW79BZTFhczBG0PRYlVMbTuX4u9FoAcSdZCI8=
-github.com/ONSdigital/dp-files-api v1.22.0/go.mod h1:vhx3E6y8UYLVco/EeJwS+Q2SQ0/jmEtXEF5Phc2Jspk=
+github.com/ONSdigital/dp-files-api v1.28.0 h1:YIiNc0tcGzpCV/En9nKbCZFBizfIk5sZIuANT+8Q0ss=
+github.com/ONSdigital/dp-files-api v1.28.0/go.mod h1:L8sSz/cOmejgfoxRXflXIvr+eIaJXGhf9gsinUn+58Q=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=
 github.com/ONSdigital/dp-healthcheck v1.6.4/go.mod h1:j3UNbGT4ZJg1chrRkPLE6YUVYCg1su3AAQ8frcBrvgc=
 github.com/ONSdigital/dp-kafka/v3 v3.11.0 h1:A2rOt2c+7unDM7McFvZEl4EsS0FbT9GJhGHR40iOM1M=

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.282.0 h1:9eR5jGMrJ7FIuALydLISRXefa
 github.com/ONSdigital/dp-api-clients-go/v2 v2.282.0/go.mod h1:vniCZ0iYfIQ5llsBigUS2khr8cSN1eXEsOKGYlopWHI=
 github.com/ONSdigital/dp-authorisation/v2 v2.34.0 h1:Zc096gAh5S7PFG1LlbM/siZDvyzd7fU11dMK8X6m98k=
 github.com/ONSdigital/dp-authorisation/v2 v2.34.0/go.mod h1:y3zXIX/x8baEKucG05v/PL86GtL7MAz9Eb3HcwZmuvQ=
-github.com/ONSdigital/dp-component-test v1.4.4-alpha h1:efo71nub0AQZO5Bxp8X5As7xytBl60qSHC/FAm08DME=
-github.com/ONSdigital/dp-component-test v1.4.4-alpha/go.mod h1:Wm4JPH5/xyehThk1zbVZ3EKizPl7PefzheFG2e2PYoo=
+github.com/ONSdigital/dp-component-test v1.4.7 h1:rl09EiuinyEWNIUMbi0zHmTOcgMo96nx1g7VuXxS/Xo=
+github.com/ONSdigital/dp-component-test v1.4.7/go.mod h1:M4AHtkKgyud7xL3drcp+CtioENDLJyUdvHjQC5DuWmQ=
 github.com/ONSdigital/dp-files-api v1.22.0 h1:aKUKfWEW79BZTFhczBG0PRYlVMbTuX4u9FoAcSdZCI8=
 github.com/ONSdigital/dp-files-api v1.22.0/go.mod h1:vhx3E6y8UYLVco/EeJwS+Q2SQ0/jmEtXEF5Phc2Jspk=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=


### PR DESCRIPTION
### What

[Jira ticket](https://officefornationalstatistics.atlassian.net/browse/DIS-5147?atlOrigin=eyJpIjoiZGQ5YzMzNjcyM2EwNGQ1Y2I0YjFiZGZlNjMyNWJhNmIiLCJwIjoiaiJ9)

When an edition has been created in the DCM, and the version/file has been added to a bundle as a content item, and a viewer group has been given permission to view the version, then the dataset ID or edition ID is changed, the viewer user can no longer download the file as the permission policy refers to the previous dataset ID or edition ID.

This change checks all permutations of the current dataset IDs and edition ID along with previous used series/edition IDs when checking permissions.

### How to review

- This needs to be tested along with the dp-files-api PR https://github.com/ONSdigital/dp-files-api/pull/214
- You will need to use the latest changes from dp-files-api in `go.mod` with (assuming dp-files-api is in the same directory your dp-download-service repo is):
```
replace (
	github.com/ONSdigital/dp-files-api v1.22.0 => ../dp-files-api
)
```
- You'll also need to add the following as a volume to the `dp-download-service.yml` manifest file in dp-compose to allow the docker to build the image
```
- ${DP_REPO_DIR:-../../../..}/dp-files-api:/dp-files-api
```
- Once built and running in your dataset catalogue stack, follow the testing instructions from the dp-files-api PR posted above.
- Lint, audit and tests will fail so this won't be able to be merged until the files-api PR has been merged and then released

### Who can review

Anyone